### PR TITLE
[#225] Hypertruncs example assertion failure

### DIFF
--- a/src/polysymmetrica/core/funcs.scad
+++ b/src/polysymmetrica/core/funcs.scad
@@ -518,6 +518,18 @@ function _ps_fix_winding_all(faces, fixed=undef) =
         _ps_fix_winding_queue(faces, _ps_list_set(init, seed, faces[seed]), [seed])
     );
 
+// Function: _ps_unique_values()
+// Usage:
+//   result = _ps_unique_values(list);
+// Description:
+//   Keep first occurrences from a scalar list.
+//   .
+//   - Returns: list with duplicate values removed
+// Arguments:
+//   list = input list
+function _ps_unique_values(list) =
+    [for (i = [0:1:len(list)-1]) if (_ps_index_of(list, list[i]) == i) list[i]];
+
 // Function: _ps_unique_face_indices()
 // Usage:
 //   result = _ps_unique_face_indices(list);
@@ -528,7 +540,7 @@ function _ps_fix_winding_all(faces, fixed=undef) =
 // Arguments:
 //   list = input list
 function _ps_unique_face_indices(list) =
-    [for (i = [0:1:len(list)-1]) if (_ps_index_of(list, list[i]) == i) list[i]];
+    _ps_unique_values(list);
 
 // Function: _ps_face_neighbor_indices()
 // Usage:
@@ -1644,6 +1656,35 @@ function ps_face_has_edge(f, a, b) =
             if ((x==a && y==b) || (x==b && y==a)) 1
     ]) > 0;
 
+// Function: _ps_face_vertex_count()
+// Usage:
+//   result = _ps_face_vertex_count(face, vi);
+// Description:
+//   Count occurrences of a vertex in one face loop.
+//   .
+//   - Returns: occurrence count
+// Arguments:
+//   face = face index loop
+//   vi = vertex index
+function _ps_face_vertex_count(face, vi) =
+    len([for (k = [0 : len(face)-1]) if (face[k] == vi) 1]);
+
+// Function: _ps_vertex_incident_face_indices()
+// Usage:
+//   result = _ps_vertex_incident_face_indices(faces, vi);
+// Description:
+//   Find face indices incident to a vertex from a face list.
+//   .
+//   - Returns: unordered face-index list
+// Arguments:
+//   faces = face list
+//   vi = vertex index
+function _ps_vertex_incident_face_indices(faces, vi) =
+    [
+        for (fi = [0 : len(faces)-1])
+            if (_ps_face_vertex_count(faces[fi], vi) > 0) fi
+    ];
+
 // Function: ps_vertex_incident_faces()
 // Usage:
 //   result = ps_vertex_incident_faces(poly, vi);
@@ -1655,12 +1696,7 @@ function ps_face_has_edge(f, a, b) =
 //   poly = poly descriptor
 //   vi = vertex index
 function ps_vertex_incident_faces(poly, vi) =
-    let(faces = poly_faces(poly))
-    [
-        for (fi = [0 : len(faces)-1])
-            let(f = faces[fi])
-            if (len([for (k = [0 : len(f)-1]) if (f[k] == vi) 1]) > 0) fi
-    ];
+    _ps_vertex_incident_face_indices(poly_faces(poly), vi);
 
 // Function: _ps_next_face_around_vertex()
 // Usage:

--- a/src/polysymmetrica/core/placement.scad
+++ b/src/polysymmetrica/core/placement.scad
@@ -45,21 +45,11 @@ function _ps_resolve_classify(poly, classify=undef, classify_opts=undef) =
             _ps_cls_opt(classify_opts, 3, false)
         );
 
-function _ps_vertex_site_face_vertex_count(face, vertex_idx) =
-    len([for (v = face) if (v == vertex_idx) v]);
-
 function _ps_vertex_site_incident_edge_idxs(edges, vertex_idx) =
     [
         for (ei = [0:1:len(edges)-1])
             if (edges[ei][0] == vertex_idx || edges[ei][1] == vertex_idx)
                 ei
-    ];
-
-function _ps_vertex_site_incident_face_idxs(faces, vertex_idx) =
-    [
-        for (fi = [0:1:len(faces)-1])
-            if (_ps_vertex_site_face_vertex_count(faces[fi], vertex_idx) > 0)
-                fi
     ];
 
 function _ps_vertex_site_face_incident_edge_count(incident_edge_idxs, edge_faces, face_idx) =
@@ -95,10 +85,10 @@ function _ps_vertex_site_reachable_faces(incident_edge_idxs, edge_faces, frontie
 function _ps_vertex_site_has_closed_fan(faces, edges, edge_faces, vertex_idx) =
     let(
         incident_edge_idxs = _ps_vertex_site_incident_edge_idxs(edges, vertex_idx),
-        incident_face_idxs = _ps_vertex_site_incident_face_idxs(faces, vertex_idx),
+        incident_face_idxs = _ps_vertex_incident_face_indices(faces, vertex_idx),
         non_simple_faces = [
             for (fi = incident_face_idxs)
-                if (_ps_vertex_site_face_vertex_count(faces[fi], vertex_idx) != 1)
+                if (_ps_face_vertex_count(faces[fi], vertex_idx) != 1)
                     fi
         ],
         non_manifold = [
@@ -328,56 +318,6 @@ function _ps_face_site_from_local_poly(face_idx, faces, verts_local, poly_center
         face_local_context
     ];
 
-// Function: _ps_edge_idx_from_verts()
-// Usage:
-//   result = _ps_edge_idx_from_verts(edges, a, b);
-// Description:
-//   Find the canonical global edge index for two vertex ids.
-//   .
-//   - Returns: edge index, or `-1` when absent
-// Arguments:
-//   edges = canonical edge list
-//   a = edge endpoint vertex ids
-//   b = edge endpoint vertex ids
-function _ps_edge_idx_from_verts(edges, a, b) =
-    let(e = (a < b) ? [a, b] : [b, a])
-    _ps_edge_idx_from_canonical(edges, e);
-
-// Function: _ps_edge_idx_from_canonical()
-// Usage:
-//   result = _ps_edge_idx_from_canonical(edges, e, i);
-// Description:
-//   Find the index of a canonical edge pair without `search(...)`.
-//   .
-//   - Returns: edge index, or `-1` when absent
-// Arguments:
-//   edges = canonical edge list
-//   e = canonical edge pair
-//   i = recursion state
-function _ps_edge_idx_from_canonical(edges, e, i=0) =
-    (i >= len(edges)) ? -1 :
-    (edges[i][0] == e[0] && edges[i][1] == e[1]) ? i :
-    _ps_edge_idx_from_canonical(edges, e, i + 1);
-
-// Function: _ps_unique_values()
-// Usage:
-//   result = _ps_unique_values(vals, i, acc);
-// Description:
-//   Deduplicate scalar values while preserving first-seen order.
-//   .
-//   - Returns: unique values
-// Arguments:
-//   vals = input values
-//   i = recursion state
-//   acc = recursion state
-function _ps_unique_values(vals, i=0, acc=[]) =
-    (i >= len(vals)) ? acc :
-    _ps_unique_values(
-        vals,
-        i + 1,
-        _ps_list_contains(acc, vals[i]) ? acc : concat(acc, [vals[i]])
-    );
-
 // Function: _ps_edge_site_from_local_poly()
 // Usage:
 //   result = _ps_edge_site_from_local_poly(edge_idx, faces, verts_local, poly_center_local_parent, eps);
@@ -535,10 +475,9 @@ function _ps_proxy_edge_ids_from_face_record(record, faces, verts_local, eps=1e-
                 let(
                     a = f[k],
                     b = f[(k + 1) % len(f)],
-                    edge_idx = _ps_edge_idx_from_verts(edges, a, b)
+                    edge_idx = ps_find_edge_index(edges, a, b)
                 )
-                if (edge_idx >= 0)
-                    edge_idx
+                edge_idx
         ]
     )
     _ps_unique_values(ids);

--- a/src/polysymmetrica/core/placement.scad
+++ b/src/polysymmetrica/core/placement.scad
@@ -45,20 +45,91 @@ function _ps_resolve_classify(poly, classify=undef, classify_opts=undef) =
             _ps_cls_opt(classify_opts, 3, false)
         );
 
-function _ps_vertex_site_has_closed_fan(edges, edge_faces, vertex_idx) =
+function _ps_vertex_site_face_vertex_count(face, vertex_idx) =
+    len([for (v = face) if (v == vertex_idx) v]);
+
+function _ps_vertex_site_incident_edge_idxs(edges, vertex_idx) =
+    [
+        for (ei = [0:1:len(edges)-1])
+            if (edges[ei][0] == vertex_idx || edges[ei][1] == vertex_idx)
+                ei
+    ];
+
+function _ps_vertex_site_incident_face_idxs(faces, vertex_idx) =
+    [
+        for (fi = [0:1:len(faces)-1])
+            if (_ps_vertex_site_face_vertex_count(faces[fi], vertex_idx) > 0)
+                fi
+    ];
+
+function _ps_vertex_site_face_incident_edge_count(incident_edge_idxs, edge_faces, face_idx) =
+    len([
+        for (ei = incident_edge_idxs)
+            if (_ps_list_contains(edge_faces[ei], face_idx))
+                ei
+    ]);
+
+function _ps_vertex_site_adjacent_faces(incident_edge_idxs, edge_faces, face_idx) =
+    _ps_unique_values([
+        for (ei = incident_edge_idxs)
+            if (_ps_list_contains(edge_faces[ei], face_idx))
+                for (fi = edge_faces[ei])
+                    if (fi != face_idx)
+                        fi
+    ]);
+
+function _ps_vertex_site_reachable_faces(incident_edge_idxs, edge_faces, frontier, seen=[]) =
     let(
-        incident_edge_idxs = [
-            for (ei = [0:1:len(edges)-1])
-                if (edges[ei][0] == vertex_idx || edges[ei][1] == vertex_idx)
-                    ei
+        seen1 = _ps_unique_values(concat(seen, frontier)),
+        next = _ps_unique_values([
+            for (fi = frontier)
+                for (adj = _ps_vertex_site_adjacent_faces(incident_edge_idxs, edge_faces, fi))
+                    if (!_ps_list_contains(seen1, adj))
+                        adj
+        ])
+    )
+    (len(next) == 0)
+        ? seen1
+        : _ps_vertex_site_reachable_faces(incident_edge_idxs, edge_faces, next, seen1);
+
+function _ps_vertex_site_has_closed_fan(faces, edges, edge_faces, vertex_idx) =
+    let(
+        incident_edge_idxs = _ps_vertex_site_incident_edge_idxs(edges, vertex_idx),
+        incident_face_idxs = _ps_vertex_site_incident_face_idxs(faces, vertex_idx),
+        non_simple_faces = [
+            for (fi = incident_face_idxs)
+                if (_ps_vertex_site_face_vertex_count(faces[fi], vertex_idx) != 1)
+                    fi
         ],
         non_manifold = [
             for (ei = incident_edge_idxs)
                 if (len(edge_faces[ei]) != 2)
                     ei
-        ]
+        ],
+        foreign_edge_faces = [
+            for (ei = incident_edge_idxs)
+                if (len(edge_faces[ei]) == 2)
+                    for (fi = edge_faces[ei])
+                        if (!_ps_list_contains(incident_face_idxs, fi))
+                            fi
+        ],
+        bad_face_degrees = [
+            for (fi = incident_face_idxs)
+                if (_ps_vertex_site_face_incident_edge_count(incident_edge_idxs, edge_faces, fi) != 2)
+                    fi
+        ],
+        reachable = (len(incident_face_idxs) == 0 || len(non_manifold) > 0)
+            ? []
+            : _ps_vertex_site_reachable_faces(incident_edge_idxs, edge_faces, [incident_face_idxs[0]])
     )
-    len(incident_edge_idxs) > 0 && len(non_manifold) == 0;
+    len(incident_edge_idxs) > 0
+        && len(incident_face_idxs) > 0
+        && len(incident_edge_idxs) == len(incident_face_idxs)
+        && len(non_simple_faces) == 0
+        && len(non_manifold) == 0
+        && len(foreign_edge_faces) == 0
+        && len(bad_face_degrees) == 0
+        && len(reachable) == len(incident_face_idxs);
 
 // Function: _ps_face_site_neighbors_idx()
 // Usage:
@@ -399,7 +470,7 @@ function _ps_vertex_site_from_local_poly(vertex_idx, faces, verts_local, poly_ce
         poly_center_parent = is_undef(poly_center_local_parent) ? [0, 0, 0] : poly_center_local_parent,
         radial_raw = center - poly_center_parent,
         ez = (norm(radial_raw) <= eps) ? [0, 0, 1] : v_norm(radial_raw),
-        closed_fan = _ps_vertex_site_has_closed_fan(edges, edge_faces, vertex_idx),
+        closed_fan = _ps_vertex_site_has_closed_fan(faces, edges, edge_faces, vertex_idx),
         neighbors_idx = closed_fan
             ? ps_vertex_fan_neighbors_idx(ps_vertex_fan(local_poly, vertex_idx, edges, edge_faces))
             : _ps_vertex_site_neighbors_idx(edges, vertex_idx),
@@ -1825,7 +1896,7 @@ function ps_edge_sites(poly, inter_radius = 1, edge_len = undef, classify = unde
 //   .
 //   - Returns: list of vertex site records `[vertex_idx, edge_len, vert_radius, poly_center_local, vertex_valence, vertex_neighbors_idx, vertex_neighbor_pts_local, vertex_family_id, face_family_count, edge_family_count, vertex_family_count, frame]`
 //   .
-//   - Limitations/Gotchas: closed-manifold vertices use cyclic fan order anchored at the lowest neighbour index; boundary vertices keep edge-scan neighbour order so open construction outputs remain placeable
+//   - Limitations/Gotchas: simple closed-manifold vertices use cyclic fan order anchored at the lowest neighbour index; boundary and singular vertices keep edge-scan neighbour order so open construction outputs and degenerate construction results remain placeable
 // Arguments:
 //   poly = source poly descriptor.
 //   inter_radius = target interradius scale used when `edge_len` is `undef`.
@@ -1852,7 +1923,7 @@ function ps_vertex_sites(poly, inter_radius = 1, edge_len = undef, classify = un
             let(
                 v0 = verts[vi] * scale,
                 ez = v_norm(v0),
-                closed_fan = _ps_vertex_site_has_closed_fan(edges, edge_faces, vi),
+                closed_fan = _ps_vertex_site_has_closed_fan(faces, edges, edge_faces, vi),
                 neighbors_idx = closed_fan
                     ? ps_vertex_fan_neighbors_idx(ps_vertex_fan(poly, vi, edges, edge_faces))
                     : _ps_vertex_site_neighbors_idx(edges, vi),

--- a/src/tests/core/TestPlacement.scad
+++ b/src/tests/core/TestPlacement.scad
@@ -463,7 +463,7 @@ module test_ps_vertex_sites__open_construction_outputs_remain_placeable() {
 
         for (site = sites) {
             vi = ps_vertex_site_idx(site);
-            expected = _test_vertex_has_boundary_edge(edges, edge_faces, vi)
+            expected = !_ps_vertex_site_has_closed_fan(faces, edges, edge_faces, vi)
                 ? _ps_vertex_site_neighbors_idx(edges, vi)
                 : ps_vertex_fan_neighbors_idx(ps_vertex_fan(p, vi, edges, edge_faces));
             assert(
@@ -472,6 +472,52 @@ module test_ps_vertex_sites__open_construction_outputs_remain_placeable() {
             );
         }
     }
+}
+
+module test_ps_vertex_sites__hypertruncated_dodecahedron_t1_singular_vertices_remain_placeable() {
+    p = poly_truncate(dodecahedron(), 1);
+    faces = poly_faces(p);
+    verts = poly_verts(p);
+    edges = _ps_edges_from_faces(faces);
+    edge_faces = ps_edge_faces_table(faces, edges);
+    sites = ps_vertex_sites(p);
+    singular_vertices = [
+        for (vi = [0:1:len(verts)-1])
+            if (!_ps_vertex_site_has_closed_fan(faces, edges, edge_faces, vi))
+                vi
+    ];
+
+    assert_int_eq(len(sites), len(verts), "hypertruncated dodecahedron t=1 should produce one vertex site per vertex");
+    assert(len(singular_vertices) > 0, "hypertruncated dodecahedron t=1 should exercise singular vertex-site fallback");
+
+    for (vi = singular_vertices) {
+        expected = _ps_vertex_site_neighbors_idx(edges, vi);
+        assert(
+            ps_vertex_site_neighbors_idx(sites[vi]) == expected,
+            str("singular hypertruncated vertex should use edge-scan order vi=", vi, " got=", ps_vertex_site_neighbors_idx(sites[vi]), " expected=", expected)
+        );
+    }
+
+    place_on_vertices(p, indices = singular_vertices[0])
+        assert_int_eq($ps_vertex_valence, len(_ps_vertex_site_neighbors_idx(edges, $ps_vertex_idx)), "singular hypertruncated vertex placement valence");
+}
+
+module test_ps_vertex_site_from_local_poly__pinched_vertex_uses_edge_scan_order() {
+    verts = [[1,0,0], [2,0,0], [1,1,0], [1,0,1], [0,0,0], [1,-1,0], [1,0,-1]];
+    faces = [
+        [0,1,2], [0,3,1], [0,2,3], [1,3,2],
+        [0,5,4], [0,4,6], [0,6,5], [4,5,6]
+    ];
+    edges = _ps_edges_from_faces(faces);
+    edge_faces = ps_edge_faces_table(faces, edges);
+    site = _ps_vertex_site_from_local_poly(0, faces, verts);
+    expected = _ps_vertex_site_neighbors_idx(edges, 0);
+
+    assert(!_ps_vertex_site_has_closed_fan(faces, edges, edge_faces, 0), "pinched vertex should not be classified as a simple closed fan");
+    assert(
+        ps_vertex_site_neighbors_idx(site) == expected,
+        str("pinched local vertex site should use edge-scan order got=", ps_vertex_site_neighbors_idx(site), " expected=", expected)
+    );
 }
 
 module test_ps_vertex_site_from_local_poly__closed_ring_uses_fan_order() {
@@ -1085,9 +1131,11 @@ module run_TestPlacement() {
     test_ps_vertex_fan__rhombicuboctahedron_neighbors_are_cyclic_and_anchored();
     test_ps_vertex_sites__neighbors_match_vertex_fan_order();
     test_ps_vertex_sites__open_construction_outputs_remain_placeable();
+    test_ps_vertex_sites__hypertruncated_dodecahedron_t1_singular_vertices_remain_placeable();
     test_ps_vertex_site_from_local_poly__closed_ring_uses_fan_order();
     test_ps_vertex_site_from_local_poly__does_not_rebuild_local_poly();
     test_ps_vertex_site_from_local_poly__open_ring_uses_edge_scan_order();
+    test_ps_vertex_site_from_local_poly__pinched_vertex_uses_edge_scan_order();
     test_ps_vertex_site_accessors__match_record_layout();
     test_ps_vertex_site_frame__matches_site_accessors();
     test_ps_vertex_sites__truncated_tetrahedron_frames_are_orthonormal();


### PR DESCRIPTION
  What changed:

  - Moved generic _ps_unique_values() into src/polysymmetrica/core/funcs.scad.
  - Added shared _ps_face_vertex_count() and _ps_vertex_incident_face_indices() helpers in funcs.scad.
  - Removed placement-local duplicates for unique values, incident-face scanning, face vertex counting, and edge index lookup.
  - Replaced placement’s local edge lookup with existing ps_find_edge_index().

  Verified:

  - Focused TestPlacement via watcher: pass
  - Full src/tests/run_all.scad via watcher: pass
  - docsgen parse: pass
  - diff whitespace check for touched files: pass
