### PR TITLE
[#245] Refactor poly_truncate to use shared vertex figure realization

### DIFF
--- a/src/polysymmetrica/core/truncation.scad
+++ b/src/polysymmetrica/core/truncation.scad
@@ -233,110 +233,56 @@ function _ps_index_of_min(list) =
 function _ps_truncate_norm_to_t(poly, c) =
     _ps_truncate_default_t(poly) * c;
 
-function _ps_truncate_cap_mode_is_valid(cap_mode) =
-    ps_vertex_figure_cap_mode_is_valid(cap_mode);
-
 function _ps_truncate_cap_mode_ok(cap_mode) =
-    assert(_ps_truncate_cap_mode_is_valid(cap_mode))
+    assert(ps_vertex_figure_cap_mode_is_valid(cap_mode))
     0;
 
 function _ps_truncate_cap_modes_ok(cap_modes) =
     let(
         bad = [
             for (i = [0:1:len(cap_modes)-1])
-                if (!_ps_truncate_cap_mode_is_valid(cap_modes[i])) i
+                if (!ps_vertex_figure_cap_mode_is_valid(cap_modes[i])) i
         ],
         _ok = assert(len(bad) == 0, str("poly_truncate: unsupported cap_mode at vertices ", bad))
     )
     0;
 
-function _ps_truncate_points_centroid(pts) =
-    v_sum(pts) / len(pts);
-
-function _ps_truncate_edge_point_for_vertex(verts, edge, vi, t) =
+function _ps_truncate_vertex_cap_data(poly0, vi, edges, edge_faces, t_by_vert, cap_mode_by_vert, eps) =
     let(
-        a = edge[0],
-        b = edge[1],
-        _has = assert(a == vi || b == vi, "poly_truncate: edge does not contain vertex"),
-        A = verts[vi],
-        B = verts[(a == vi) ? b : a]
-    )
-    A + t * (B - A);
-
-function _ps_truncate_raw_cap_points_for_vertex(verts, edges, t_by_vert, poly0, edge_faces, vi) =
-    let(
-        tv = t_by_vert[vi],
         fig = ps_vertex_figure(poly0, vi, edges, edge_faces),
-        cap_edges = ps_vertex_figure_edges_idx(fig)
+        cap_edges = ps_vertex_figure_edges_idx(fig),
+        cap_points = ps_vertex_figure_points(poly0, vi, t_by_vert[vi], cap_mode_by_vert[vi], edges, edge_faces, eps)
     )
-    [
-        for (ei = cap_edges)
-            _ps_truncate_edge_point_for_vertex(verts, edges[ei], vi, tv)
-    ];
+    [cap_edges, cap_points];
 
-function _ps_truncate_vertex_cut_plane(verts, edges, t_by_vert, poly0, edge_faces, vi, cap_mode, poly_center, eps) =
+function _ps_truncate_vertex_cap_point_for_edge(vertex_cap_data, edge_idx) =
     let(
-        pts = _ps_truncate_raw_cap_points_for_vertex(verts, edges, t_by_vert, poly0, edge_faces, vi),
-        n_raw = (cap_mode == "planar_edge_fraction")
-            ? let(idx = [for (i = [0:1:len(pts)-1]) i])
-                ps_face_frame_normal(pts, idx, eps)
-            : (cap_mode == "centric")
-                ? (_ps_truncate_points_centroid(pts) - verts[vi])
-                : (verts[vi] - poly_center),
-        n_len = norm(n_raw),
-        _n_ok = assert(n_len > eps, str("poly_truncate: cannot derive ", cap_mode, " cap plane for vertex ", vi)),
-        n = n_raw / n_len,
-        d = ps_sum([for (p = pts) v_dot(n, p)]) / len(pts)
+        cap_edges = vertex_cap_data[0],
+        cap_points = vertex_cap_data[1],
+        idx = _ps_index_of(cap_edges, edge_idx)
     )
-    [n, d];
+    (idx < 0) ? undef : cap_points[idx];
 
-function _ps_truncate_vertex_cut_planes(verts, edges, t_by_vert, poly0, edge_faces, cap_mode_by_vert, eps) =
-    let(
-        poly_center = _ps_truncate_points_centroid(verts)
-    )
-    [
-        for (vi = [0:1:len(verts)-1])
-            (abs(t_by_vert[vi]) <= eps || cap_mode_by_vert[vi] == "edge_fraction")
-                ? undef
-                : _ps_truncate_vertex_cut_plane(verts, edges, t_by_vert, poly0, edge_faces, vi, cap_mode_by_vert[vi], poly_center, eps)
-    ];
-
-function _ps_truncate_plane_edge_point_for_vertex(verts, edge, vi, plane, eps) =
-    let(
-        a = edge[0],
-        b = edge[1],
-        _has = assert(a == vi || b == vi, "poly_truncate: edge does not contain vertex"),
-        A = verts[vi],
-        B = verts[(a == vi) ? b : a],
-        dir = B - A,
-        n = plane[0],
-        d = plane[1],
-        denom = v_dot(n, dir),
-        _denom_ok = assert(abs(denom) > eps, "poly_truncate: cap plane is parallel to incident edge"),
-        lambda = (d - v_dot(n, A)) / denom
-    )
-    A + lambda * dir;
-
-function _ps_truncate_edge_points_by_vert_cap_mode(verts, edges, t_by_vert, poly0, edge_faces, cap_mode_by_vert, eps) =
+function _ps_truncate_edge_points_by_vert_cap_mode(vert_count, edges, t_by_vert, poly0, edge_faces, cap_mode_by_vert, eps) =
     let(
         _modes_ok = _ps_truncate_cap_modes_ok(cap_mode_by_vert),
-        planes = _ps_truncate_vertex_cut_planes(verts, edges, t_by_vert, poly0, edge_faces, cap_mode_by_vert, eps)
+        vertex_cap_data = [
+            for (vi = [0:1:vert_count-1])
+                _ps_truncate_vertex_cap_data(poly0, vi, edges, edge_faces, t_by_vert, cap_mode_by_vert, eps)
+        ]
     )
     [
         for (ei = [0:1:len(edges)-1])
             let(
                 e = edges[ei],
                 a = e[0],
-                b = e[1]
+                b = e[1],
+                pa = _ps_truncate_vertex_cap_point_for_edge(vertex_cap_data[a], ei),
+                pb = _ps_truncate_vertex_cap_point_for_edge(vertex_cap_data[b], ei),
+                _pa_ok = assert(!is_undef(pa), str("poly_truncate: vertex ", a, " has no cap point for edge ", ei)),
+                _pb_ok = assert(!is_undef(pb), str("poly_truncate: vertex ", b, " has no cap point for edge ", ei))
             )
-            [
-                is_undef(planes[a])
-                    ? _ps_truncate_edge_point_for_vertex(verts, e, a, t_by_vert[a])
-                    : _ps_truncate_plane_edge_point_for_vertex(verts, e, a, planes[a], eps),
-                is_undef(planes[b])
-                    ? _ps_truncate_edge_point_for_vertex(verts, e, b, t_by_vert[b])
-                    : _ps_truncate_plane_edge_point_for_vertex(verts, e, b, planes[b], eps)
-            ]
+            [pa, pb]
     ];
 
 // Function: poly_truncate()
@@ -424,7 +370,7 @@ function poly_truncate(
             q = all_zero
             ? poly
             : let(
-                edge_pts = _ps_truncate_edge_points_by_vert_cap_mode(verts, edges, t_by_vert, poly0, edge_faces, cap_mode_by_vert, eps),
+                edge_pts = _ps_truncate_edge_points_by_vert_cap_mode(len(verts), edges, t_by_vert, poly0, edge_faces, cap_mode_by_vert, eps),
                 sites = [
                     for (ei = [0:1:len(edges)-1])
                         each [[ei, edges[ei][0]], [ei, edges[ei][1]]]

--- a/src/tests/core/TestTruncation.scad
+++ b/src/tests/core/TestTruncation.scad
@@ -9,6 +9,7 @@ use <../../polysymmetrica/core/duals.scad>
 use <../../polysymmetrica/core/prisms.scad>
 use <../../polysymmetrica/core/transform.scad>
 use <../../polysymmetrica/core/truncation.scad>
+use <../../polysymmetrica/core/vertex.scad>
 use <../../polysymmetrica/core/solvers.scad>
 use <../../polysymmetrica/core/validate.scad>
 use <../../polysymmetrica/models/platonics_all.scad>
@@ -78,6 +79,11 @@ function _max_vertex_diff(p1, p2) =
         n = min(len(v1), len(v2))
     )
     (n == 0) ? 0 : max([for (i = [0:1:n-1]) norm(v1[i] - v2[i])]);
+
+function _points_max_diff(a, b) =
+    (len(a) != len(b)) ? 1e99
+        : (len(a) == 0) ? 0
+        : max([for (i = [0:1:len(a)-1]) norm(a[i] - b[i])]);
 
 function _skew_quad_prism() =
     let(
@@ -280,6 +286,55 @@ module test_poly_truncate__cap_mode_profile_overrides_by_vertex() {
     assert(
         _ps_face_planarity_err(poly_verts(q), apex_cap) > 1e-3,
         "vertex profile cap_mode=edge_fraction should preserve the raw skew cap at that vertex"
+    );
+}
+
+module test_poly_truncate__cap_points_match_vertex_figure_helper() {
+    p = _irregular_valence4_bipyramid();
+    verts = poly_verts(p);
+    edges = _ps_edges_from_faces(poly_faces(p));
+    edge_faces = ps_edge_faces_table(poly_faces(p), edges);
+    poly0 = p;
+    modes = ps_vertex_figure_cap_modes();
+
+    for (mode = modes) {
+        actual_by_edge = _ps_truncate_edge_points_by_vert_cap_mode(
+            len(verts),
+            edges,
+            [for (vi = [0:1:len(verts)-1]) 0.22],
+            poly0,
+            edge_faces,
+            [for (vi = [0:1:len(verts)-1]) mode],
+            EPS
+        );
+        fig = ps_vertex_figure(poly0, 0, edges, edge_faces);
+        cap_edges = ps_vertex_figure_edges_idx(fig);
+        actual = [for (ei = cap_edges) actual_by_edge[ei][edges[ei][0] == 0 ? 0 : 1]];
+        expected = ps_vertex_figure_points(poly0, 0, t = 0.22, cap_mode = mode, edges = edges, edge_faces = edge_faces);
+
+        assert(
+            _points_max_diff(actual, expected) < 1e-8,
+            str("poly_truncate cap points should match shared helper for mode ", mode, " actual=", actual, " expected=", expected)
+        );
+    }
+
+    actual_profile_by_edge = _ps_truncate_edge_points_by_vert_cap_mode(
+        len(verts),
+        edges,
+        [for (vi = [0:1:len(verts)-1]) 0.22],
+        poly0,
+        edge_faces,
+        concat(["edge_fraction"], [for (vi = [1:1:len(verts)-1]) "planar_edge_fraction"]),
+        EPS
+    );
+    fig_profile = ps_vertex_figure(poly0, 0, edges, edge_faces);
+    cap_edges_profile = ps_vertex_figure_edges_idx(fig_profile);
+    actual_profile = [for (ei = cap_edges_profile) actual_profile_by_edge[ei][edges[ei][0] == 0 ? 0 : 1]];
+    expected_profile = ps_vertex_figure_points(poly0, 0, t = 0.22, cap_mode = "edge_fraction", edges = edges, edge_faces = edge_faces);
+
+    assert(
+        _points_max_diff(actual_profile, expected_profile) < 1e-8,
+        str("poly_truncate profile cap_mode override should match shared helper actual=", actual_profile, " expected=", expected_profile)
     );
 }
 
@@ -849,6 +904,7 @@ module run_TestTruncation() {
     test_poly_truncate__planar_cap_mode_handles_irregular_valence4();
     test_poly_truncate__alternate_cap_modes_handle_irregular_valence4();
     test_poly_truncate__cap_mode_profile_overrides_by_vertex();
+    test_poly_truncate__cap_points_match_vertex_figure_helper();
     test_poly_rectify__star_prism_keeps_star_ok_output();
     test_poly_cantitruncate__tetra_counts();
     test_poly_cantellate__profile_face_df_and_c();


### PR DESCRIPTION
`poly_truncate(...)` now consumes `ps_vertex_figure_points(...)` for cap realization instead of carrying its own duplicate raw/planar/centric/poly-centroidal geometry. Truncation still owns profile resolution, topology/site assembly, and transform construction.

Added a focused TestTruncation check for the irregular valence-4 bipyramid, covering all cap modes plus the cap-mode override path.
