### PR TITLE
[#266] Edge-volume model

### DIFF
--- a/docs/reference/placement_data_model.md
+++ b/docs/reference/placement_data_model.md
@@ -278,6 +278,12 @@ when it can. Boundary or degenerate edges fall back to a radial frame.
 `ps_placement_frame(...)` tail element to each site record; the frame is the
 stored source of truth for edge center/axis accessors.
 
+For edge-owned CSG regions, `polysymmetrica/core/edge_regions.scad` provides
+`ps_edge_region_shells(...)` and `ps_edge_region_volume(...)`. These derive
+edge-region atom shells from the adjacent faces' filled boundary spans, then
+emit them in the same edge-local frame: X follows the edge and Z follows the
+adjacent-face normal bisector.
+
 Describe example:
 
 ```scad

--- a/src/examples/basics/main_edge_region_volume.scad
+++ b/src/examples/basics/main_edge_region_volume.scad
@@ -1,0 +1,47 @@
+/*
+ * This file is part of PolySymmetrica, a Polyhedral Geometry Modelling System.
+ * Copyright 2025-2026 Susan Witts
+ * SPDX-License-Identifier: MIT
+ */
+
+use <../../polysymmetrica/core/edge_regions.scad>
+use <../../polysymmetrica/core/placement.scad>
+use <../../polysymmetrica/core/truncation.scad>
+use <../../polysymmetrica/models/archimedians_all.scad>
+use <../../polysymmetrica/models/catalans_all.scad>
+use <../../polysymmetrica/models/platonics_all.scad>
+
+IR = 26;
+OUTSET = 1.4;
+Z_MIN = -1.2;
+Z_MAX = 2.0;
+SPACING = 92;
+
+module edge_region_preview(poly, label_s) {
+    color("lightgray")
+        place_on_edges(poly, IR)
+            cube([$ps_edge_len, 0.45, 0.45], center = true);
+
+    color("indianred", 0.72)
+        place_on_edges(poly, IR)
+            ps_edge_region_volume(poly, outset = OUTSET, z0 = Z_MIN, z1 = Z_MAX, inter_radius = IR);
+
+    translate([0, -36, -18])
+        linear_extrude(height = 0.4)
+            text(label_s, size = 4, halign = "center", valign = "center");
+}
+
+translate([-SPACING * 2.5, 0, 0])
+    edge_region_preview(poly_truncate(tetrahedron(), -1), "atet");
+
+translate([-SPACING * 1.5, 0, 0])
+    edge_region_preview(tetrahedron(), "tetrahedron");
+
+translate([-SPACING * 0.5, 0, 0])
+    edge_region_preview(icosidodecahedron(), "icosidodecahedron");
+
+translate([SPACING * 0.5, 0, 0])
+    edge_region_preview(rhombic_triacontahedron(), "rhombic triacontahedron");
+
+translate([SPACING * 1.5, 0, 0])
+    edge_region_preview(poly_truncate(dodecahedron(), t = 0.42), "truncated dodeca t=0.42");

--- a/src/polysymmetrica/core/edge_regions.scad
+++ b/src/polysymmetrica/core/edge_regions.scad
@@ -302,7 +302,7 @@ function ps_edge_region_shells(poly, outset, z0, z1, inter_radius=1, edge_len=un
         _outset = assert(outset > eps, "ps_edge_region_shells: outset must be positive"),
         _z0 = assert(!is_undef(z0), "ps_edge_region_shells: z0 must be defined"),
         _z1 = assert(!is_undef(z1), "ps_edge_region_shells: z1 must be defined"),
-        _height = assert(abs(z1 - z0) > eps, "ps_edge_region_shells: z0 and z1 must differ"),
+        _height = assert(z1 > z0 + eps, "ps_edge_region_shells: z1 must be greater than z0"),
         edge_site = ps_edge_sites(poly, inter_radius, edge_len)[edge_idx],
         edge_verts = ps_edge_site_verts_idx(edge_site),
         adj_faces = ps_edge_site_adj_faces_idx(edge_site),

--- a/src/polysymmetrica/core/edge_regions.scad
+++ b/src/polysymmetrica/core/edge_regions.scad
@@ -1,0 +1,230 @@
+/*
+ * This file is part of PolySymmetrica, a Polyhedral Geometry Modelling System.
+ * Copyright 2025-2026 Susan Witts
+ * SPDX-License-Identifier: MIT
+ */
+
+// LibFile: polysymmetrica/core/edge_regions.scad
+use <funcs.scad>
+use <loop_shells.scad>
+use <placement.scad>
+include <segments.scad>
+
+function _ps_er_face_source_edge_idx(face, edge_verts, k=0) =
+    (k >= len(face)) ? undef :
+    let(a = face[k], b = face[(k + 1) % len(face)])
+    ((a == edge_verts[0] && b == edge_verts[1]) || (a == edge_verts[1] && b == edge_verts[0]))
+        ? k
+        : _ps_er_face_source_edge_idx(face, edge_verts, k + 1);
+
+function _ps_er_global_t_range(site, face, edge_verts, eps=1e-8) =
+    let(
+        k = ps_boundary_span_site_source_edge_idx(site),
+        a = face[k],
+        b = face[(k + 1) % len(face)],
+        same_dir = a == edge_verts[0] && b == edge_verts[1],
+        t0_raw = ps_boundary_span_site_source_t0(site),
+        t1_raw = ps_boundary_span_site_source_t1(site),
+        t0 = same_dir ? t0_raw : 1 - t0_raw,
+        t1 = same_dir ? t1_raw : 1 - t1_raw
+    )
+    [min(t0, t1), max(t0, t1)];
+
+function _ps_er_face_edge_boundary_spans(face_site, edge_verts, mode="nonzero", eps=1e-8) =
+    let(
+        face_ctx = ps_face_site_face_local_context(face_site),
+        face_idx = ps_face_local_context_idx(face_ctx),
+        face = ps_face_local_context_poly_faces_idx(face_ctx)[face_idx],
+        source_edge_idx = _ps_er_face_source_edge_idx(face, edge_verts),
+        _edge = assert(!is_undef(source_edge_idx), "ps_edge_region_shells: adjacent face does not contain edge"),
+        sites = _ps_face_boundary_span_sites(
+            ps_face_local_context_pts3d_local(face_ctx),
+            face_idx,
+            ps_face_local_context_poly_faces_idx(face_ctx),
+            ps_face_local_context_poly_verts_local(face_ctx),
+            ps_face_local_context_neighbors_idx(face_ctx),
+            ps_face_local_context_dihedrals(face_ctx),
+            mode,
+            eps
+        )
+    )
+    [
+        for (site = sites)
+            if (ps_boundary_span_site_source_edge_idx(site) == source_edge_idx)
+                [site, _ps_er_global_t_range(site, face, edge_verts, eps), face_site]
+    ];
+
+function _ps_er_span_at_t(spans, t, eps=1e-8) =
+    let(
+        hits = [
+            for (span = spans)
+                if (t >= span[1][0] - eps && t <= span[1][1] + eps)
+                    span
+        ]
+    )
+    len(hits) == 0 ? undef : hits[0];
+
+function _ps_er_unique_sorted(vals, eps=1e-8) =
+    _ps_seg_sort_uniq([for (v = vals) ps_clamp(v, 0, 1)], eps);
+
+function _ps_er_atom_intervals(spans0, spans1, eps=1e-8) =
+    let(
+        ts = _ps_er_unique_sorted(concat(
+            [0, 1],
+            [for (s = spans0) each s[1]],
+            [for (s = spans1) each s[1]]
+        ), eps)
+    )
+    [
+        for (i = [0:1:len(ts)-2])
+            let(t0 = ts[i], t1 = ts[i + 1])
+            if (t1 - t0 > eps)
+                [t0, t1, (t0 + t1) / 2]
+    ];
+
+function _ps_er_face_local_vec_to_parent(face_site, v) =
+    ps_face_site_ex(face_site) * v[0]
+        + ps_face_site_ey(face_site) * v[1]
+        + ps_face_site_ez(face_site) * v[2];
+
+function _ps_er_parent_vec_to_edge_local(edge_site, v) =
+    [
+        v_dot(v, ps_edge_site_ex(edge_site)),
+        v_dot(v, ps_edge_site_ey(edge_site)),
+        v_dot(v, ps_edge_site_ez(edge_site))
+    ];
+
+function _ps_er_span_filled_ray_face_local(site) =
+    ps_boundary_span_site_ey_local(site) * ((ps_boundary_span_site_filled_side(site) < 0) ? -1 : 1);
+
+function _ps_er_span_filled_ray_edge_local(span, edge_site, eps=1e-8) =
+    let(
+        site = span[0],
+        face_site = span[2],
+        v_parent = _ps_er_face_local_vec_to_parent(face_site, _ps_er_span_filled_ray_face_local(site)),
+        v_edge = _ps_er_parent_vec_to_edge_local(edge_site, v_parent),
+        yz = [v_edge[1], v_edge[2]],
+        _ray = assert(norm(yz) > eps, "ps_edge_region_shells: adjacent face side ray is parallel to edge")
+    )
+    yz / norm(yz);
+
+function _ps_er_side_y_for_z(ray_yz, outset, z, eps=1e-8) =
+    let(
+        _ry = assert(abs(ray_yz[0]) > eps, "ps_edge_region_shells: side ray cannot constrain edge-local Y"),
+        y = (outset - ray_yz[1] * z) / ray_yz[0]
+    )
+    y;
+
+function _ps_er_oriented_side_ys(ray0, ray1, outset, z, eps=1e-8) =
+    let(
+        y0 = _ps_er_side_y_for_z(ray0, outset, z, eps),
+        y1 = _ps_er_side_y_for_z(ray1, outset, z, eps)
+    )
+    (y0 <= y1) ? [y0, y1] : [y1, y0];
+
+function _ps_er_atom_shell(edge_site, atom, span0, span1, outset, z0, z1, eps=1e-8) =
+    let(
+        edge_len = ps_edge_site_edge_len(edge_site),
+        x0 = -edge_len / 2 + atom[0] * edge_len,
+        x1 = -edge_len / 2 + atom[1] * edge_len,
+        ray0 = _ps_er_span_filled_ray_edge_local(span0, edge_site, eps),
+        ray1 = _ps_er_span_filled_ray_edge_local(span1, edge_site, eps),
+        bottom_ys = _ps_er_oriented_side_ys(ray0, ray1, outset, z0, eps),
+        top_ys = _ps_er_oriented_side_ys(ray0, ray1, outset, z1, eps),
+        _bw = assert(bottom_ys[1] - bottom_ys[0] > eps, "ps_edge_region_shells: z0 side constraints cross or collapse"),
+        _tw = assert(top_ys[1] - top_ys[0] > eps, "ps_edge_region_shells: z1 side constraints cross or collapse"),
+        bottom_loop = [
+            [x0, bottom_ys[0]],
+            [x1, bottom_ys[0]],
+            [x1, bottom_ys[1]],
+            [x0, bottom_ys[1]]
+        ],
+        top_loop = [
+            [x0, top_ys[0]],
+            [x1, top_ys[0]],
+            [x1, top_ys[1]],
+            [x0, top_ys[1]]
+        ],
+        lineage = [
+            ps_boundary_span_site_idx(span0[0]),
+            ps_boundary_span_site_idx(span1[0])
+        ]
+    )
+    ps_loop_shell_from_loops(bottom_loop, top_loop, z0, z1, "edge_region", ps_edge_site_idx(edge_site), lineage, 0, undef, eps);
+
+// Function: ps_edge_region_shells()
+// Usage:
+//   shells = ps_edge_region_shells(poly, outset, z0, z1, inter_radius, edge_len, edge_idx, mode, eps);
+// Description:
+//   Build edge-region atom shells for one source edge.
+//   .
+//   Adjacent face boundary spans are used as the source of truth. Transition
+//   points from both adjacent faces are merged along the edge, and each interval
+//   with a stable pair of face-side spans becomes one shell.
+//   .
+//   - Returns: list of `ps_loop_shell` records
+//   .
+//   - Limitations/Gotchas: closed two-face edges only; endpoint handoff to
+//     vertex-node volumes is not applied here.
+// Arguments:
+//   poly = source poly descriptor.
+//   outset = symmetric side offset from the topological edge.
+//   z0 = lower edge-local Z bound.
+//   z1 = upper edge-local Z bound.
+//   inter_radius = target interradius scale used when `edge_len` is `undef`.
+//   edge_len = explicit target edge length; pass the same value used by `place_on_edges(...)`.
+//   edge_idx = source edge index; defaults to `$ps_edge_idx` inside `place_on_edges(...)`.
+//   mode = face fill mode used when deriving adjacent face boundary spans.
+//   eps = geometric tolerance.
+function ps_edge_region_shells(poly, outset, z0, z1, inter_radius=1, edge_len=undef, edge_idx=$ps_edge_idx, mode="nonzero", eps=1e-8) =
+    let(
+        _edge_idx = assert(!is_undef(edge_idx), "ps_edge_region_shells: edge_idx is required; call inside place_on_edges(...) or pass edge_idx"),
+        _outset = assert(outset > eps, "ps_edge_region_shells: outset must be positive"),
+        _z0 = assert(!is_undef(z0), "ps_edge_region_shells: z0 must be defined"),
+        _z1 = assert(!is_undef(z1), "ps_edge_region_shells: z1 must be defined"),
+        _height = assert(abs(z1 - z0) > eps, "ps_edge_region_shells: z0 and z1 must differ"),
+        edge_site = ps_edge_sites(poly, inter_radius, edge_len)[edge_idx],
+        edge_verts = ps_edge_site_verts_idx(edge_site),
+        adj_faces = ps_edge_site_adj_faces_idx(edge_site),
+        _closed = assert(len(adj_faces) == 2, "ps_edge_region_shells: edge must have exactly two adjacent faces"),
+        face_sites = ps_face_sites(poly, inter_radius, edge_len),
+        spans0 = _ps_er_face_edge_boundary_spans(face_sites[adj_faces[0]], edge_verts, mode, eps),
+        spans1 = _ps_er_face_edge_boundary_spans(face_sites[adj_faces[1]], edge_verts, mode, eps),
+        intervals = _ps_er_atom_intervals(spans0, spans1, eps)
+    )
+    [
+        for (atom = intervals)
+            let(
+                span0 = _ps_er_span_at_t(spans0, atom[2], eps),
+                span1 = _ps_er_span_at_t(spans1, atom[2], eps)
+            )
+            if (!is_undef(span0) && !is_undef(span1))
+                _ps_er_atom_shell(edge_site, atom, span0, span1, outset, z0, z1, eps)
+    ];
+
+// Module: ps_edge_region_volume()
+// Usage:
+//   ps_edge_region_volume(poly, outset, z0, z1, inter_radius, edge_len, edge_idx, mode, eps, convexity);
+// Description:
+//   Emit edge-region atom shells for the current or supplied source edge.
+//   .
+//   - Returns: none; intended for use inside `place_on_edges(...)`
+// Arguments:
+//   poly = source poly descriptor.
+//   outset = symmetric side offset from the topological edge.
+//   z0 = lower edge-local Z bound.
+//   z1 = upper edge-local Z bound.
+//   inter_radius = target interradius scale used when `edge_len` is `undef`.
+//   edge_len = explicit target edge length.
+//   edge_idx = source edge index; defaults to `$ps_edge_idx`.
+//   mode = face fill mode used when deriving adjacent face boundary spans.
+//   eps = geometric tolerance.
+//   convexity = OpenSCAD polyhedron convexity hint.
+module ps_edge_region_volume(poly, outset, z0, z1, inter_radius=1, edge_len=undef, edge_idx=$ps_edge_idx, mode="nonzero", eps=1e-8, convexity=6) {
+    shells = ps_edge_region_shells(poly, outset, z0, z1, inter_radius, edge_len, edge_idx, mode, eps);
+
+    union() {
+        for (shell = shells)
+            ps_loop_shell(shell, convexity);
+    }
+}

--- a/src/polysymmetrica/core/edge_regions.scad
+++ b/src/polysymmetrica/core/edge_regions.scad
@@ -207,11 +207,11 @@ function _ps_er_atom_wedge_shell(edge_site, atom, span0, span1, constraints, z_w
                 [1, 5, 2]
             ]
             : [
-                [2, 3, 4, 5],
-                [0, 1, 3, 2],
-                [0, 5, 4, 1],
-                [0, 2, 5],
-                [1, 4, 3]
+                [5, 4, 3, 2],
+                [2, 3, 1, 0],
+                [1, 4, 5, 0],
+                [5, 2, 0],
+                [3, 4, 1]
             ],
         bottom_loop = bottom_wide
             ? [[x0, wide_ys[0]], [x1, wide_ys[0]], [x1, wide_ys[1]], [x0, wide_ys[1]]]

--- a/src/polysymmetrica/core/edge_regions.scad
+++ b/src/polysymmetrica/core/edge_regions.scad
@@ -108,29 +108,50 @@ function _ps_er_span_filled_ray_edge_local(span, edge_site, eps=1e-8) =
     )
     yz / norm(yz);
 
-function _ps_er_side_y_for_z(ray_yz, outset, z, eps=1e-8) =
+function _ps_er_side_constraint(ray_yz, outset, eps=1e-8) =
     let(
         _ry = assert(abs(ray_yz[0]) > eps, "ps_edge_region_shells: side ray cannot constrain edge-local Y"),
-        y = (outset - ray_yz[1] * z) / ray_yz[0]
+        slope = -ray_yz[1] / ray_yz[0],
+        intercept = outset / ray_yz[0]
     )
-    y;
+    [slope, intercept];
 
-function _ps_er_oriented_side_ys(ray0, ray1, outset, z, eps=1e-8) =
+function _ps_er_side_constraint_y(constraint, z) =
+    constraint[0] * z + constraint[1];
+
+function _ps_er_side_constraints_cross_z(c0, c1, eps=1e-8) =
+    let(dz = c0[0] - c1[0])
+    abs(dz) <= eps ? undef : (c1[1] - c0[1]) / dz;
+
+function _ps_er_z_ordered(z0, z1) =
+    z0 <= z1 ? [z0, z1] : [z1, z0];
+
+function _ps_er_stable_z_ranges(c0, c1, z0, z1, eps=1e-8) =
     let(
-        y0 = _ps_er_side_y_for_z(ray0, outset, z, eps),
-        y1 = _ps_er_side_y_for_z(ray1, outset, z, eps)
+        zz = _ps_er_z_ordered(z0, z1),
+        za = zz[0],
+        zb = zz[1],
+        z_cross = _ps_er_side_constraints_cross_z(c0, c1, eps)
     )
-    (y0 <= y1) ? [y0, y1] : [y1, y0];
+    is_undef(z_cross) || z_cross <= za + eps || z_cross >= zb - eps
+        ? [[z0, z1]]
+        : (z0 <= z1)
+            ? [[z0, z_cross], [z_cross, z1]]
+            : [[z0, z_cross], [z_cross, z1]];
 
-function _ps_er_atom_shell(edge_site, atom, span0, span1, outset, z0, z1, eps=1e-8) =
+function _ps_er_side_ys_for_z(constraints, z) =
+    [
+        _ps_er_side_constraint_y(constraints[0], z),
+        _ps_er_side_constraint_y(constraints[1], z)
+    ];
+
+function _ps_er_atom_shell_from_constraints(edge_site, atom, span0, span1, constraints, z0, z1, eps=1e-8) =
     let(
         edge_len = ps_edge_site_edge_len(edge_site),
         x0 = -edge_len / 2 + atom[0] * edge_len,
         x1 = -edge_len / 2 + atom[1] * edge_len,
-        ray0 = _ps_er_span_filled_ray_edge_local(span0, edge_site, eps),
-        ray1 = _ps_er_span_filled_ray_edge_local(span1, edge_site, eps),
-        bottom_ys = _ps_er_oriented_side_ys(ray0, ray1, outset, z0, eps),
-        top_ys = _ps_er_oriented_side_ys(ray0, ray1, outset, z1, eps),
+        bottom_ys = _ps_er_side_ys_for_z(constraints, z0),
+        top_ys = _ps_er_side_ys_for_z(constraints, z1),
         _bw = assert(bottom_ys[1] - bottom_ys[0] > eps, "ps_edge_region_shells: z0 side constraints cross or collapse"),
         _tw = assert(top_ys[1] - top_ys[0] > eps, "ps_edge_region_shells: z1 side constraints cross or collapse"),
         bottom_loop = [
@@ -151,6 +172,105 @@ function _ps_er_atom_shell(edge_site, atom, span0, span1, outset, z0, z1, eps=1e
         ]
     )
     ps_loop_shell_from_loops(bottom_loop, top_loop, z0, z1, "edge_region", ps_edge_site_idx(edge_site), lineage, 0, undef, eps);
+
+function _ps_er_atom_wedge_shell(edge_site, atom, span0, span1, constraints, z_wide, z_tip, eps=1e-8) =
+    let(
+        edge_len = ps_edge_site_edge_len(edge_site),
+        x0 = -edge_len / 2 + atom[0] * edge_len,
+        x1 = -edge_len / 2 + atom[1] * edge_len,
+        wide_ys = _ps_er_side_ys_for_z(constraints, z_wide),
+        tip_y = _ps_er_side_constraint_y(constraints[0], z_tip),
+        bottom_wide = z_wide < z_tip,
+        points = bottom_wide
+            ? [
+                [x0, wide_ys[0], z_wide],
+                [x1, wide_ys[0], z_wide],
+                [x1, wide_ys[1], z_wide],
+                [x0, wide_ys[1], z_wide],
+                [x0, tip_y, z_tip],
+                [x1, tip_y, z_tip]
+            ]
+            : [
+                [x0, tip_y, z_tip],
+                [x1, tip_y, z_tip],
+                [x0, wide_ys[0], z_wide],
+                [x1, wide_ys[0], z_wide],
+                [x1, wide_ys[1], z_wide],
+                [x0, wide_ys[1], z_wide]
+            ],
+        faces = bottom_wide
+            ? [
+                [0, 1, 2, 3],
+                [0, 4, 5, 1],
+                [3, 2, 5, 4],
+                [0, 3, 4],
+                [1, 5, 2]
+            ]
+            : [
+                [2, 3, 4, 5],
+                [0, 1, 3, 2],
+                [0, 5, 4, 1],
+                [0, 2, 5],
+                [1, 4, 3]
+            ],
+        bottom_loop = bottom_wide
+            ? [[x0, wide_ys[0]], [x1, wide_ys[0]], [x1, wide_ys[1]], [x0, wide_ys[1]]]
+            : [[x0, tip_y], [x1, tip_y]],
+        top_loop = bottom_wide
+            ? [[x0, tip_y], [x1, tip_y]]
+            : [[x0, wide_ys[0]], [x1, wide_ys[0]], [x1, wide_ys[1]], [x0, wide_ys[1]]],
+        lineage = [
+            ps_boundary_span_site_idx(span0[0]),
+            ps_boundary_span_site_idx(span1[0])
+        ]
+    )
+    [
+        "loop_shell",
+        points,
+        faces,
+        bottom_loop,
+        top_loop,
+        min(z_wide, z_tip),
+        max(z_wide, z_tip),
+        "edge_region",
+        ps_edge_site_idx(edge_site),
+        lineage,
+        0,
+        undef
+    ];
+
+function _ps_er_atom_shell_for_stable_z(edge_site, atom, span0, span1, constraints, za, zb, eps=1e-8) =
+    let(
+        ya = _ps_er_side_ys_for_z(constraints, za),
+        yb = _ps_er_side_ys_for_z(constraints, zb),
+        wa = ya[1] - ya[0],
+        wb = yb[1] - yb[0],
+        _valid = assert(wa >= -eps && wb >= -eps, "ps_edge_region_shells: stable side constraints are reversed"),
+        wide_z = wa > wb ? za : zb,
+        tip_z = wa > wb ? zb : za
+    )
+    (wa <= eps || wb <= eps)
+        ? _ps_er_atom_wedge_shell(edge_site, atom, span0, span1, constraints, wide_z, tip_z, eps)
+        : _ps_er_atom_shell_from_constraints(edge_site, atom, span0, span1, constraints, za, zb, eps);
+
+function _ps_er_atom_shells(edge_site, atom, span0, span1, outset, z0, z1, eps=1e-8) =
+    let(
+        ray0 = _ps_er_span_filled_ray_edge_local(span0, edge_site, eps),
+        ray1 = _ps_er_span_filled_ray_edge_local(span1, edge_site, eps),
+        c0 = _ps_er_side_constraint(ray0, outset, eps),
+        c1 = _ps_er_side_constraint(ray1, outset, eps),
+        ranges = _ps_er_stable_z_ranges(c0, c1, z0, z1, eps)
+    )
+    [
+        for (range = ranges)
+            let(
+                z_mid = (range[0] + range[1]) / 2,
+                y0_mid = _ps_er_side_constraint_y(c0, z_mid),
+                y1_mid = _ps_er_side_constraint_y(c1, z_mid),
+                constraints = y0_mid <= y1_mid ? [c0, c1] : [c1, c0]
+            )
+            _ps_er_atom_shell_for_stable_z(edge_site, atom, span0, span1, constraints, range[0], range[1], eps)
+    ];
 
 // Function: ps_edge_region_shells()
 // Usage:
@@ -199,7 +319,7 @@ function ps_edge_region_shells(poly, outset, z0, z1, inter_radius=1, edge_len=un
                 span1 = _ps_er_span_at_t(spans1, atom[2], eps)
             )
             if (!is_undef(span0) && !is_undef(span1))
-                _ps_er_atom_shell(edge_site, atom, span0, span1, outset, z0, z1, eps)
+                each _ps_er_atom_shells(edge_site, atom, span0, span1, outset, z0, z1, eps)
     ];
 
 // Module: ps_edge_region_volume()

--- a/src/tests/core/TestEdgeRegions.scad
+++ b/src/tests/core/TestEdgeRegions.scad
@@ -1,0 +1,84 @@
+/*
+ * This file is part of PolySymmetrica, a Polyhedral Geometry Modelling System.
+ * Copyright 2025-2026 Susan Witts
+ * SPDX-License-Identifier: MIT
+ */
+
+use <../../polysymmetrica/core/edge_regions.scad>
+use <../../polysymmetrica/core/loop_shells.scad>
+use <../../polysymmetrica/core/placement.scad>
+use <../../polysymmetrica/core/truncation.scad>
+use <../../polysymmetrica/models/platonics_all.scad>
+
+EPS = 1e-8;
+
+module assert_int_eq(a, b, msg="") {
+    assert(a == b, str(msg, " expected=", b, " got=", a));
+}
+
+module assert_near(a, b, eps=EPS, msg="") {
+    assert(abs(a - b) <= eps, str(msg, " expected=", b, " got=", a));
+}
+
+function _test_coord(points, axis) = [for (p = points) p[axis]];
+
+function _test_shell_points_are_finite(points) =
+    len([
+        for (p = points)
+            if (!is_undef(p) && len(p) == 3 && norm(p) < 1e9)
+                1
+    ]) == len(points);
+
+module test_ps_edge_region_shells__tetra_edge_single_atom() {
+    p = tetrahedron();
+    shells = ps_edge_region_shells(p, outset = 0.4, z0 = -0.3, z1 = 0.6, inter_radius = 12, edge_idx = 0);
+    shell = shells[0];
+    pts = ps_loop_shell_points(shell);
+
+    assert_int_eq(len(shells), 1, "tetrahedron edge should have one edge-region atom");
+    assert_int_eq(len(pts), 8, "edge shell should have bottom+top rectangle vertices");
+    assert_int_eq(len(ps_loop_shell_faces(shell)), 8, "edge shell should have two triangulated caps plus four sides");
+    assert(ps_loop_shell_source_kind(shell) == "edge_region", "edge shell source kind");
+    assert_int_eq(ps_loop_shell_source_idx(shell), 0, "edge shell source idx");
+    assert_near(min(_test_coord(pts, 2)), -0.3, EPS, "edge shell z min");
+    assert_near(max(_test_coord(pts, 2)), 0.6, EPS, "edge shell z max");
+    assert(_test_shell_points_are_finite(pts), "edge shell points should be finite");
+}
+
+module test_ps_edge_region_shells__uses_edge_placement_context() {
+    p = hexahedron();
+    place_on_edges(p, edge_len = 12, indices = 0) {
+        shells = ps_edge_region_shells(p, outset = 0.4, z0 = -0.5, z1 = 1.5, edge_len = 12);
+        pts = ps_loop_shell_points(shells[0]);
+
+        assert_int_eq(len(shells), 1, "cube edge should have one edge-region atom");
+        assert_int_eq(ps_loop_shell_source_idx(shells[0]), $ps_edge_idx, "edge shell should inherit source edge idx");
+        assert_near(min(_test_coord(pts, 0)), -$ps_edge_len / 2, EPS, "context edge shell x min");
+        assert_near(max(_test_coord(pts, 0)), $ps_edge_len / 2, EPS, "context edge shell x max");
+        assert_near(min(_test_coord(pts, 2)), -0.5, EPS, "context edge shell z min");
+        assert_near(max(_test_coord(pts, 2)), 1.5, EPS, "context edge shell z max");
+    }
+}
+
+module test_ps_edge_region_shells__anti_tet_splits_some_edges() {
+    p = poly_truncate(tetrahedron(), t = -0.5);
+    edge_count = len(ps_edge_sites(p));
+    shell_counts = [
+        for (ei = [0:1:edge_count-1])
+            len(ps_edge_region_shells(p, outset = 0.2, z0 = -0.2, z1 = 0.2, inter_radius = 10, edge_idx = ei))
+    ];
+
+    assert(max(shell_counts) > 1, str("anti-truncated tetrahedron should split at least one edge into multiple atoms counts=", shell_counts));
+}
+
+module run_TestEdgeRegions() {
+    echo("Running TestEdgeRegions...");
+    test_ps_edge_region_shells__tetra_edge_single_atom();
+    test_ps_edge_region_shells__uses_edge_placement_context();
+    test_ps_edge_region_shells__anti_tet_splits_some_edges();
+    echo("TestEdgeRegions passed");
+}
+
+run_TestEdgeRegions();
+
+cube([0.01, 0.01, 0.01], center = true);

--- a/src/tests/core/TestEdgeRegions.scad
+++ b/src/tests/core/TestEdgeRegions.scad
@@ -71,11 +71,44 @@ module test_ps_edge_region_shells__anti_tet_splits_some_edges() {
     assert(max(shell_counts) > 1, str("anti-truncated tetrahedron should split at least one edge into multiple atoms counts=", shell_counts));
 }
 
+module test_ps_edge_region_shells__crossing_side_constraints_split_z_range() {
+    p = poly_truncate(tetrahedron(), t = -1);
+    edge_count = len(ps_edge_sites(p));
+    shell_counts = [
+        for (ei = [0:1:edge_count-1])
+            len(ps_edge_region_shells(p, outset = 1.4, z0 = -1.2, z1 = 2, inter_radius = 26, edge_idx = ei))
+    ];
+
+    assert(max(shell_counts) > 1, str("crossing side constraints should split edge region shells counts=", shell_counts));
+}
+
+module test_ps_edge_region_shells__side_constraints_preserve_identity() {
+    constraints = [[0, -0.4], [0, 0.4]];
+    bottom_ys = _ps_er_side_ys_for_z(constraints, -1);
+    top_ys = _ps_er_side_ys_for_z(constraints, 1);
+
+    assert_near(bottom_ys[0], -0.4, EPS, "bottom left constraint should keep its source identity");
+    assert_near(bottom_ys[1], 0.4, EPS, "bottom right constraint should keep its source identity");
+    assert_near(top_ys[0], -0.4, EPS, "top left constraint should keep its source identity");
+    assert_near(top_ys[1], 0.4, EPS, "top right constraint should keep its source identity");
+}
+
+module test_ps_edge_region_shells__crossing_constraints_are_split_at_crossing_z() {
+    ranges = _ps_er_stable_z_ranges([1, -0.4], [-1, 0.4], -1, 1, EPS);
+
+    assert_int_eq(len(ranges), 2, "crossing constraints should split into two stable z ranges");
+    assert_near(ranges[0][1], 0.4, EPS, "first split should end at crossing z");
+    assert_near(ranges[1][0], 0.4, EPS, "second split should start at crossing z");
+}
+
 module run_TestEdgeRegions() {
     echo("Running TestEdgeRegions...");
     test_ps_edge_region_shells__tetra_edge_single_atom();
     test_ps_edge_region_shells__uses_edge_placement_context();
     test_ps_edge_region_shells__anti_tet_splits_some_edges();
+    test_ps_edge_region_shells__crossing_side_constraints_split_z_range();
+    test_ps_edge_region_shells__side_constraints_preserve_identity();
+    test_ps_edge_region_shells__crossing_constraints_are_split_at_crossing_z();
     echo("TestEdgeRegions passed");
 }
 

--- a/src/tests/core/TestEdgeRegions.scad
+++ b/src/tests/core/TestEdgeRegions.scad
@@ -5,6 +5,7 @@
  */
 
 use <../../polysymmetrica/core/edge_regions.scad>
+use <../../polysymmetrica/core/funcs.scad>
 use <../../polysymmetrica/core/loop_shells.scad>
 use <../../polysymmetrica/core/placement.scad>
 use <../../polysymmetrica/core/truncation.scad>
@@ -82,6 +83,28 @@ module test_ps_edge_region_shells__crossing_side_constraints_split_z_range() {
     assert(max(shell_counts) > 1, str("crossing side constraints should split edge region shells counts=", shell_counts));
 }
 
+module test_ps_edge_region_shells__crossing_wedges_are_lhr_outward() {
+    p = poly_truncate(tetrahedron(), t = -1);
+    edge_count = len(ps_edge_sites(p));
+    shells = [
+        for (ei = [0:1:edge_count-1])
+            each ps_edge_region_shells(p, outset = 1.4, z0 = -1.2, z1 = 2, inter_radius = 26, edge_idx = ei)
+    ];
+    wedge_shells = [
+        for (shell = shells)
+            if (len(ps_loop_shell_points(shell)) == 6)
+                shell
+    ];
+    inward_wedges = [
+        for (shell = wedge_shells)
+            if (_ps_faces_signed_volume6_rhr(ps_loop_shell_points(shell), ps_loop_shell_faces(shell)) >= -EPS)
+                shell
+    ];
+
+    assert(len(wedge_shells) > 0, "crossing case should produce wedge shells");
+    assert_int_eq(len(inward_wedges), 0, "crossing wedge shells should be LHR outward");
+}
+
 module test_ps_edge_region_shells__side_constraints_preserve_identity() {
     constraints = [[0, -0.4], [0, 0.4]];
     bottom_ys = _ps_er_side_ys_for_z(constraints, -1);
@@ -107,6 +130,7 @@ module run_TestEdgeRegions() {
     test_ps_edge_region_shells__uses_edge_placement_context();
     test_ps_edge_region_shells__anti_tet_splits_some_edges();
     test_ps_edge_region_shells__crossing_side_constraints_split_z_range();
+    test_ps_edge_region_shells__crossing_wedges_are_lhr_outward();
     test_ps_edge_region_shells__side_constraints_preserve_identity();
     test_ps_edge_region_shells__crossing_constraints_are_split_at_crossing_z();
     echo("TestEdgeRegions passed");

--- a/src/tests/negative/edge_region_reversed_z_bounds.scad
+++ b/src/tests/negative/edge_region_reversed_z_bounds.scad
@@ -1,0 +1,12 @@
+/*
+ * This file is part of PolySymmetrica, a Polyhedral Geometry Modelling System.
+ * Copyright 2025-2026 Susan Witts
+ * SPDX-License-Identifier: MIT
+ */
+
+use <../../polysymmetrica/core/edge_regions.scad>
+use <../../polysymmetrica/models/platonics_all.scad>
+
+shells = ps_edge_region_shells(tetrahedron(), outset = 0.4, z0 = 1, z1 = -1, edge_idx = 0);
+
+cube([0.01, 0.01, 0.01], center = true);

--- a/src/tests/run_all.scad
+++ b/src/tests/run_all.scad
@@ -13,6 +13,7 @@ use <core/TestCleanup.scad>
 use <core/TestValidity.scad>
 use <core/TestClassify.scad>
 use <core/TestPlacement.scad>
+use <core/TestEdgeRegions.scad>
 use <core/TestFaceRegions.scad>
 use <core/TestSelfCrossing.scad>
 use <core/TestPrisms.scad>
@@ -31,6 +32,7 @@ run_TestCleanup();
 run_TestValidity();
 run_TestClassify();
 run_TestPlacement();
+run_TestEdgeRegions();
 run_TestFaceRegions();
 run_TestSelfCrossing();
 run_TestPrisms();


### PR DESCRIPTION
Added src/polysymmetrica/core/edge_regions.scad, with `ps_edge_region_shells(...)` and ps_edge_region_volume(...). The new approach derives edge-region atom shells from the two adjacent faces’ filled boundary spans, so anti-truncated tetrahedron cases can split an edge into multiple volumes instead of forcing one cuboid corridor.

  Also added focused tests in `src/tests/core/TestEdgeRegions.scad`, registered them in `src/tests/run_all.scad`, documented the new edge-region helpers in `docs/reference/placement_data_model.md`, and added a visual/example playground at `src/examples/basics/main_edge_region_volume.scad`.
