### PR TITLE
[#269] Edge region context cache

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -186,7 +186,7 @@ This has multiple advantages:
 These operators attach arbitrary geometry to each face/edge/vertex of a polyhedron:
 
 * `place_on_faces(poly, inter_radius, edge_len=undef, classify=undef, classify_opts=undef, indices=undef)`
-* `place_on_edges(poly, inter_radius, edge_len=undef, classify=undef, classify_opts=undef, indices=undef)`
+* `place_on_edges(poly, inter_radius, edge_len=undef, classify=undef, classify_opts=undef, indices=undef, edge_regions=false, edge_region_eps=1e-8)`
 * `place_on_vertices(poly, inter_radius, edge_len=undef, classify=undef, classify_opts=undef, indices=undef)`
 
 Or calculate it based on edge length:

--- a/docs/reference/placement_data_model.md
+++ b/docs/reference/placement_data_model.md
@@ -282,11 +282,15 @@ For edge-owned CSG regions, `polysymmetrica/core/edge_regions.scad` provides
 `ps_edge_region_shells(...)` and `ps_edge_region_volume(...)`. These derive
 edge-region atom shells from the adjacent faces' filled boundary spans, then
 emit them in the same edge-local frame: X follows the edge and Z follows the
-adjacent-face normal bisector. When generating volumes for many edges of the
-same polyhedron, build `ps_edge_region_context(...)` once and call
+adjacent-face normal bisector. For placement-driven edge volumes, call
+`place_on_edges(..., edge_regions = true)` and then use
+`ps_current_edge_region_shells(...)` or `ps_current_edge_region_volume(...)`
+inside the child block; `place_on_edges(...)` precomputes the shared context
+once for that loop. For custom loops or explicit context reuse, build
+`ps_edge_region_context(...)` once and call
 `ps_edge_region_shells_from_context(...)` or
-`ps_edge_region_volume_from_context(...)` inside `place_on_edges(...)`; the
-one-off functions are convenience wrappers for isolated edges.
+`ps_edge_region_volume_from_context(...)`. The one-off functions are
+convenience wrappers for isolated edges.
 
 Describe example:
 

--- a/docs/reference/placement_data_model.md
+++ b/docs/reference/placement_data_model.md
@@ -282,7 +282,11 @@ For edge-owned CSG regions, `polysymmetrica/core/edge_regions.scad` provides
 `ps_edge_region_shells(...)` and `ps_edge_region_volume(...)`. These derive
 edge-region atom shells from the adjacent faces' filled boundary spans, then
 emit them in the same edge-local frame: X follows the edge and Z follows the
-adjacent-face normal bisector.
+adjacent-face normal bisector. When generating volumes for many edges of the
+same polyhedron, build `ps_edge_region_context(...)` once and call
+`ps_edge_region_shells_from_context(...)` or
+`ps_edge_region_volume_from_context(...)` inside `place_on_edges(...)`; the
+one-off functions are convenience wrappers for isolated edges.
 
 Describe example:
 

--- a/src/examples/basics/main_edge_region_volume.scad
+++ b/src/examples/basics/main_edge_region_volume.scad
@@ -12,19 +12,21 @@ use <../../polysymmetrica/models/catalans_all.scad>
 use <../../polysymmetrica/models/platonics_all.scad>
 
 IR = 26;
-OUTSET = 1.4;
+OUTSET = 1.5;
 Z_MIN = -1.2;
 Z_MAX = 2.0;
 SPACING = 92;
 
 module edge_region_preview(poly, label_s) {
+    ctx = ps_edge_region_context(poly, inter_radius = IR);
+
     color("lightgray")
         place_on_edges(poly, IR)
             cube([$ps_edge_len, 0.45, 0.45], center = true);
 
     color("indianred", 0.72)
         place_on_edges(poly, IR)
-            ps_edge_region_volume(poly, outset = OUTSET, z0 = Z_MIN, z1 = Z_MAX, inter_radius = IR);
+            ps_edge_region_volume_from_context(ctx, outset = OUTSET, z0 = Z_MIN, z1 = Z_MAX);
 
     translate([0, -36, -18])
         linear_extrude(height = 0.4)

--- a/src/examples/basics/main_edge_region_volume.scad
+++ b/src/examples/basics/main_edge_region_volume.scad
@@ -18,15 +18,13 @@ Z_MAX = 2.0;
 SPACING = 92;
 
 module edge_region_preview(poly, label_s) {
-    ctx = ps_edge_region_context(poly, inter_radius = IR);
-
     color("lightgray")
         place_on_edges(poly, IR)
             cube([$ps_edge_len, 0.45, 0.45], center = true);
 
     color("indianred", 0.72)
-        place_on_edges(poly, IR)
-            ps_edge_region_volume_from_context(ctx, outset = OUTSET, z0 = Z_MIN, z1 = Z_MAX);
+        place_on_edges(poly, IR, edge_regions = true)
+            ps_current_edge_region_volume(outset = OUTSET, z0 = Z_MIN, z1 = Z_MAX);
 
     translate([0, -36, -18])
         linear_extrude(height = 0.4)

--- a/src/polysymmetrica/core/edge_regions.scad
+++ b/src/polysymmetrica/core/edge_regions.scad
@@ -30,29 +30,40 @@ function _ps_er_global_t_range(site, face, edge_verts, eps=1e-8) =
     )
     [min(t0, t1), max(t0, t1)];
 
-function _ps_er_face_edge_boundary_spans(face_site, edge_verts, mode="nonzero", eps=1e-8) =
+function _ps_er_face_boundary_span_sites(face_site, mode="nonzero", eps=1e-8) =
+    let(face_ctx = ps_face_site_face_local_context(face_site))
+    _ps_face_boundary_span_sites(
+        ps_face_local_context_pts3d_local(face_ctx),
+        ps_face_local_context_idx(face_ctx),
+        ps_face_local_context_poly_faces_idx(face_ctx),
+        ps_face_local_context_poly_verts_local(face_ctx),
+        ps_face_local_context_neighbors_idx(face_ctx),
+        ps_face_local_context_dihedrals(face_ctx),
+        mode,
+        eps
+    );
+
+function _ps_er_face_edge_boundary_spans_from_sites(face_site, sites, edge_verts, eps=1e-8) =
     let(
         face_ctx = ps_face_site_face_local_context(face_site),
         face_idx = ps_face_local_context_idx(face_ctx),
         face = ps_face_local_context_poly_faces_idx(face_ctx)[face_idx],
         source_edge_idx = _ps_er_face_source_edge_idx(face, edge_verts),
-        _edge = assert(!is_undef(source_edge_idx), "ps_edge_region_shells: adjacent face does not contain edge"),
-        sites = _ps_face_boundary_span_sites(
-            ps_face_local_context_pts3d_local(face_ctx),
-            face_idx,
-            ps_face_local_context_poly_faces_idx(face_ctx),
-            ps_face_local_context_poly_verts_local(face_ctx),
-            ps_face_local_context_neighbors_idx(face_ctx),
-            ps_face_local_context_dihedrals(face_ctx),
-            mode,
-            eps
-        )
+        _edge = assert(!is_undef(source_edge_idx), "ps_edge_region_shells: adjacent face does not contain edge")
     )
     [
         for (site = sites)
             if (ps_boundary_span_site_source_edge_idx(site) == source_edge_idx)
                 [site, _ps_er_global_t_range(site, face, edge_verts, eps), face_site]
     ];
+
+function _ps_er_face_edge_boundary_spans(face_site, edge_verts, mode="nonzero", eps=1e-8) =
+    _ps_er_face_edge_boundary_spans_from_sites(
+        face_site,
+        _ps_er_face_boundary_span_sites(face_site, mode, eps),
+        edge_verts,
+        eps
+    );
 
 function _ps_er_span_at_t(spans, t, eps=1e-8) =
     let(
@@ -272,6 +283,93 @@ function _ps_er_atom_shells(edge_site, atom, span0, span1, outset, z0, z1, eps=1
             _ps_er_atom_shell_for_stable_z(edge_site, atom, span0, span1, constraints, range[0], range[1], eps)
     ];
 
+function _ps_er_shells_from_edge_spans(edge_site, spans0, spans1, outset, z0, z1, eps=1e-8) =
+    let(intervals = _ps_er_atom_intervals(spans0, spans1, eps))
+    [
+        for (atom = intervals)
+            let(
+                span0 = _ps_er_span_at_t(spans0, atom[2], eps),
+                span1 = _ps_er_span_at_t(spans1, atom[2], eps)
+            )
+            if (!is_undef(span0) && !is_undef(span1))
+                each _ps_er_atom_shells(edge_site, atom, span0, span1, outset, z0, z1, eps)
+    ];
+
+function _ps_edge_region_context(edge_sites, face_sites, face_span_sites, mode, eps) =
+    ["edge_region_context", edge_sites, face_sites, face_span_sites, mode, eps];
+
+function _ps_edge_region_context_edge_sites(ctx) = ctx[1];
+function _ps_edge_region_context_face_sites(ctx) = ctx[2];
+function _ps_edge_region_context_face_span_sites(ctx) = ctx[3];
+function _ps_edge_region_context_eps(ctx) = ctx[5];
+
+// Function: ps_edge_region_context()
+// Usage:
+//   ctx = ps_edge_region_context(poly, inter_radius, edge_len, mode, eps, classify, classify_opts);
+// Description:
+//   Precompute shared edge-region source data for a polyhedron.
+//   .
+//   Use this when generating edge-region shells for many edges of the same
+//   polyhedron. It avoids rebuilding placement sites and face boundary spans for
+//   every edge.
+//   .
+//   - Returns: opaque edge-region context record for `ps_edge_region_shells_from_context(...)`
+// Arguments:
+//   poly = source poly descriptor.
+//   inter_radius = target interradius scale used when `edge_len` is `undef`.
+//   edge_len = explicit target edge length; pass the same value used by `place_on_edges(...)`.
+//   mode = face fill mode used when deriving adjacent face boundary spans.
+//   eps = geometric tolerance.
+//   classify = optional `poly_classify(...)` result to reuse for placement site family ids.
+//   classify_opts = optional `[detail, eps, radius, include_geom]` tuple used to compute classification when `classify` is `undef`.
+function ps_edge_region_context(poly, inter_radius=1, edge_len=undef, mode="nonzero", eps=1e-8, classify=undef, classify_opts=undef) =
+    let(
+        edge_sites = ps_edge_sites(poly, inter_radius, edge_len, classify, classify_opts),
+        face_sites = ps_face_sites(poly, inter_radius, edge_len, classify, classify_opts),
+        face_span_sites = [
+            for (face_site = face_sites)
+                _ps_er_face_boundary_span_sites(face_site, mode, eps)
+        ]
+    )
+    _ps_edge_region_context(edge_sites, face_sites, face_span_sites, mode, eps);
+
+// Function: ps_edge_region_shells_from_context()
+// Usage:
+//   shells = ps_edge_region_shells_from_context(ctx, outset, z0, z1, edge_idx, eps);
+// Description:
+//   Build edge-region atom shells for one source edge using a precomputed context.
+//   .
+//   - Returns: list of `ps_loop_shell` records
+//   .
+//   - Limitations/Gotchas: closed two-face edges only; `ctx` must have been
+//     built with the same poly scale and fill mode intended for this shell.
+// Arguments:
+//   ctx = edge-region context from `ps_edge_region_context(...)`.
+//   outset = symmetric side offset from the topological edge.
+//   z0 = lower edge-local Z bound.
+//   z1 = upper edge-local Z bound.
+//   edge_idx = source edge index; defaults to `$ps_edge_idx` inside `place_on_edges(...)`.
+//   eps = geometric tolerance for this shell construction; defaults to the context tolerance.
+function ps_edge_region_shells_from_context(ctx, outset, z0, z1, edge_idx=$ps_edge_idx, eps=undef) =
+    let(
+        eps0 = is_undef(eps) ? _ps_edge_region_context_eps(ctx) : eps,
+        _kind = assert(ctx[0] == "edge_region_context", "ps_edge_region_shells_from_context: ctx must be an edge-region context"),
+        _edge_idx = assert(!is_undef(edge_idx), "ps_edge_region_shells_from_context: edge_idx is required; call inside place_on_edges(...) or pass edge_idx"),
+        _outset = assert(outset > eps0, "ps_edge_region_shells_from_context: outset must be positive"),
+        _z0 = assert(!is_undef(z0), "ps_edge_region_shells_from_context: z0 must be defined"),
+        _z1 = assert(!is_undef(z1), "ps_edge_region_shells_from_context: z1 must be defined"),
+        _height = assert(z1 > z0 + eps0, "ps_edge_region_shells_from_context: z1 must be greater than z0"),
+        edge_site = _ps_edge_region_context_edge_sites(ctx)[edge_idx],
+        edge_verts = ps_edge_site_verts_idx(edge_site),
+        adj_faces = ps_edge_site_adj_faces_idx(edge_site),
+        _closed = assert(len(adj_faces) == 2, "ps_edge_region_shells_from_context: edge must have exactly two adjacent faces"),
+        face_sites = _ps_edge_region_context_face_sites(ctx),
+        face_span_sites = _ps_edge_region_context_face_span_sites(ctx),
+        spans0 = _ps_er_face_edge_boundary_spans_from_sites(face_sites[adj_faces[0]], face_span_sites[adj_faces[0]], edge_verts, eps0),
+        spans1 = _ps_er_face_edge_boundary_spans_from_sites(face_sites[adj_faces[1]], face_span_sites[adj_faces[1]], edge_verts, eps0)
+    )
+    _ps_er_shells_from_edge_spans(edge_site, spans0, spans1, outset, z0, z1, eps0);
+
 // Function: ps_edge_region_shells()
 // Usage:
 //   shells = ps_edge_region_shells(poly, outset, z0, z1, inter_radius, edge_len, edge_idx, mode, eps);
@@ -309,18 +407,34 @@ function ps_edge_region_shells(poly, outset, z0, z1, inter_radius=1, edge_len=un
         _closed = assert(len(adj_faces) == 2, "ps_edge_region_shells: edge must have exactly two adjacent faces"),
         face_sites = ps_face_sites(poly, inter_radius, edge_len),
         spans0 = _ps_er_face_edge_boundary_spans(face_sites[adj_faces[0]], edge_verts, mode, eps),
-        spans1 = _ps_er_face_edge_boundary_spans(face_sites[adj_faces[1]], edge_verts, mode, eps),
-        intervals = _ps_er_atom_intervals(spans0, spans1, eps)
+        spans1 = _ps_er_face_edge_boundary_spans(face_sites[adj_faces[1]], edge_verts, mode, eps)
     )
-    [
-        for (atom = intervals)
-            let(
-                span0 = _ps_er_span_at_t(spans0, atom[2], eps),
-                span1 = _ps_er_span_at_t(spans1, atom[2], eps)
-            )
-            if (!is_undef(span0) && !is_undef(span1))
-                each _ps_er_atom_shells(edge_site, atom, span0, span1, outset, z0, z1, eps)
-    ];
+    _ps_er_shells_from_edge_spans(edge_site, spans0, spans1, outset, z0, z1, eps);
+
+// Module: ps_edge_region_volume_from_context()
+// Usage:
+//   ps_edge_region_volume_from_context(ctx, outset, z0, z1, edge_idx, eps, convexity);
+// Description:
+//   Emit edge-region atom shells for the current or supplied source edge using
+//   a precomputed edge-region context.
+//   .
+//   - Returns: none; intended for use inside `place_on_edges(...)`
+// Arguments:
+//   ctx = edge-region context from `ps_edge_region_context(...)`.
+//   outset = symmetric side offset from the topological edge.
+//   z0 = lower edge-local Z bound.
+//   z1 = upper edge-local Z bound.
+//   edge_idx = source edge index; defaults to `$ps_edge_idx`.
+//   eps = geometric tolerance for this shell construction; defaults to the context tolerance.
+//   convexity = OpenSCAD polyhedron convexity hint.
+module ps_edge_region_volume_from_context(ctx, outset, z0, z1, edge_idx=$ps_edge_idx, eps=undef, convexity=6) {
+    shells = ps_edge_region_shells_from_context(ctx, outset, z0, z1, edge_idx, eps);
+
+    union() {
+        for (shell = shells)
+            ps_loop_shell(shell, convexity);
+    }
+}
 
 // Module: ps_edge_region_volume()
 // Usage:

--- a/src/polysymmetrica/core/edge_regions.scad
+++ b/src/polysymmetrica/core/edge_regions.scad
@@ -295,14 +295,6 @@ function _ps_er_shells_from_edge_spans(edge_site, spans0, spans1, outset, z0, z1
                 each _ps_er_atom_shells(edge_site, atom, span0, span1, outset, z0, z1, eps)
     ];
 
-function _ps_edge_region_context(edge_sites, face_sites, face_span_sites, mode, eps) =
-    ["edge_region_context", edge_sites, face_sites, face_span_sites, mode, eps];
-
-function _ps_edge_region_context_edge_sites(ctx) = ctx[1];
-function _ps_edge_region_context_face_sites(ctx) = ctx[2];
-function _ps_edge_region_context_face_span_sites(ctx) = ctx[3];
-function _ps_edge_region_context_eps(ctx) = ctx[5];
-
 // Function: ps_edge_region_context()
 // Usage:
 //   ctx = ps_edge_region_context(poly, inter_radius, edge_len, mode, eps, classify, classify_opts);
@@ -324,14 +316,15 @@ function _ps_edge_region_context_eps(ctx) = ctx[5];
 //   classify_opts = optional `[detail, eps, radius, include_geom]` tuple used to compute classification when `classify` is `undef`.
 function ps_edge_region_context(poly, inter_radius=1, edge_len=undef, mode="nonzero", eps=1e-8, classify=undef, classify_opts=undef) =
     let(
-        edge_sites = ps_edge_sites(poly, inter_radius, edge_len, classify, classify_opts),
-        face_sites = ps_face_sites(poly, inter_radius, edge_len, classify, classify_opts),
+        base = _ps_placement_base(poly, inter_radius, edge_len, classify, classify_opts),
+        edge_sites = _ps_edge_sites_from_base(base),
+        face_sites = _ps_face_sites_from_base(base),
         face_span_sites = [
             for (face_site = face_sites)
                 _ps_er_face_boundary_span_sites(face_site, mode, eps)
         ]
     )
-    _ps_edge_region_context(edge_sites, face_sites, face_span_sites, mode, eps);
+    _ps_edge_region_context(edge_sites, face_sites, face_span_sites, eps);
 
 // Function: ps_edge_region_shells_from_context()
 // Usage:
@@ -369,6 +362,25 @@ function ps_edge_region_shells_from_context(ctx, outset, z0, z1, edge_idx=$ps_ed
         spans1 = _ps_er_face_edge_boundary_spans_from_sites(face_sites[adj_faces[1]], face_span_sites[adj_faces[1]], edge_verts, eps0)
     )
     _ps_er_shells_from_edge_spans(edge_site, spans0, spans1, outset, z0, z1, eps0);
+
+// Function: ps_current_edge_region_shells()
+// Usage:
+//   shells = ps_current_edge_region_shells(outset, z0, z1, edge_idx, eps, ctx);
+// Description:
+//   Build edge-region atom shells for the current edge using the context
+//   precomputed by `place_on_edges(..., edge_regions = true)`.
+//   .
+//   - Returns: list of `ps_loop_shell` records
+// Arguments:
+//   outset = symmetric side offset from the topological edge.
+//   z0 = lower edge-local Z bound.
+//   z1 = upper edge-local Z bound.
+//   edge_idx = source edge index; defaults to `$ps_edge_idx`.
+//   eps = optional geometric tolerance override.
+//   ctx = optional explicit context; defaults to the current placement context.
+function ps_current_edge_region_shells(outset, z0, z1, edge_idx=$ps_edge_idx, eps=undef, ctx=$_ps_edge_region_context) =
+    let(_ctx = assert(!is_undef(ctx), "ps_current_edge_region_shells: requires place_on_edges(..., edge_regions = true) or an explicit ctx"))
+    ps_edge_region_shells_from_context(ctx, outset, z0, z1, edge_idx, eps);
 
 // Function: ps_edge_region_shells()
 // Usage:
@@ -434,6 +446,27 @@ module ps_edge_region_volume_from_context(ctx, outset, z0, z1, edge_idx=$ps_edge
         for (shell = shells)
             ps_loop_shell(shell, convexity);
     }
+}
+
+// Module: ps_current_edge_region_volume()
+// Usage:
+//   ps_current_edge_region_volume(outset, z0, z1, edge_idx, eps, convexity, ctx);
+// Description:
+//   Emit edge-region atom shells for the current edge using the context
+//   precomputed by `place_on_edges(..., edge_regions = true)`.
+//   .
+//   - Returns: none; intended for use inside `place_on_edges(..., edge_regions = true)`
+// Arguments:
+//   outset = symmetric side offset from the topological edge.
+//   z0 = lower edge-local Z bound.
+//   z1 = upper edge-local Z bound.
+//   edge_idx = source edge index; defaults to `$ps_edge_idx`.
+//   eps = optional geometric tolerance override.
+//   convexity = OpenSCAD polyhedron convexity hint.
+//   ctx = optional explicit context; defaults to the current placement context.
+module ps_current_edge_region_volume(outset, z0, z1, edge_idx=$ps_edge_idx, eps=undef, convexity=6, ctx=$_ps_edge_region_context) {
+    assert(!is_undef(ctx), "ps_current_edge_region_volume: requires place_on_edges(..., edge_regions = true) or an explicit ctx");
+    ps_edge_region_volume_from_context(ctx, outset, z0, z1, edge_idx, eps, convexity);
 }
 
 // Module: ps_edge_region_volume()

--- a/src/polysymmetrica/core/placement.scad
+++ b/src/polysymmetrica/core/placement.scad
@@ -46,6 +46,72 @@ function _ps_resolve_classify(poly, classify=undef, classify_opts=undef) =
             _ps_cls_opt(classify_opts, 3, false)
         );
 
+function _ps_placement_base(poly, inter_radius=1, edge_len=undef, classify=undef, classify_opts=undef) =
+    let(
+        exp_edge_len = is_undef(edge_len) ? inter_radius * poly_e_over_ir(poly) : edge_len,
+        verts = poly_verts(poly),
+        faces = poly_faces(poly),
+        faces0 = ps_orient_all_faces_outward(verts, faces),
+        edges = _ps_edges_from_faces(faces),
+        edge_faces = ps_edge_faces_table(faces0, edges),
+        face_n = [for (f = faces0) ps_face_frame_normal(verts, f)],
+        cls = _ps_resolve_classify(poly, classify, classify_opts),
+        family_counts = is_undef(cls) ? undef : ps_classify_counts(cls)
+    )
+    [
+        "placement_base",
+        poly,
+        exp_edge_len,
+        verts,
+        faces,
+        faces0,
+        edges,
+        edge_faces,
+        face_n,
+        cls,
+        family_counts
+    ];
+
+function _ps_placement_base_poly(base) = base[1];
+function _ps_placement_base_edge_len(base) = base[2];
+function _ps_placement_base_verts(base) = base[3];
+function _ps_placement_base_faces(base) = base[4];
+function _ps_placement_base_faces_oriented(base) = base[5];
+function _ps_placement_base_edges(base) = base[6];
+function _ps_placement_base_edge_faces(base) = base[7];
+function _ps_placement_base_face_normals(base) = base[8];
+function _ps_placement_base_classify(base) = base[9];
+function _ps_placement_base_family_counts(base) = base[10];
+
+function _ps_edge_region_context(edge_sites, face_sites, face_span_sites, eps) =
+    ["edge_region_context", edge_sites, face_sites, face_span_sites, eps];
+
+function _ps_edge_region_context_edge_sites(ctx) = ctx[1];
+function _ps_edge_region_context_face_sites(ctx) = ctx[2];
+function _ps_edge_region_context_face_span_sites(ctx) = ctx[3];
+function _ps_edge_region_context_eps(ctx) = ctx[4];
+
+function _ps_edge_region_face_boundary_span_sites(face_site, eps=1e-8) =
+    let(face_ctx = ps_face_site_face_local_context(face_site))
+    _ps_face_boundary_span_sites(
+        ps_face_local_context_pts3d_local(face_ctx),
+        ps_face_local_context_idx(face_ctx),
+        ps_face_local_context_poly_faces_idx(face_ctx),
+        ps_face_local_context_poly_verts_local(face_ctx),
+        ps_face_local_context_neighbors_idx(face_ctx),
+        ps_face_local_context_dihedrals(face_ctx),
+        "nonzero",
+        eps
+    );
+
+function _ps_edge_region_context_from_sites(edge_sites, face_sites, eps=1e-8) =
+    _ps_edge_region_context(
+        edge_sites,
+        face_sites,
+        [for (face_site = face_sites) _ps_edge_region_face_boundary_span_sites(face_site, eps)],
+        eps
+    );
+
 // Function: _ps_face_site_neighbors_idx()
 // Usage:
 //   result = _ps_face_site_neighbors_idx(face, fi, faces0, edges, edge_faces);
@@ -1072,18 +1138,19 @@ function ps_proxy_volume_group_face_replay_sites(group, ctx, eps=1e-8) =
 //   edge_len = explicit target edge length; overrides `inter_radius`.
 //   classify = optional `poly_classify(...)` result to reuse for family ids.
 //   classify_opts = optional `[detail, eps, radius, include_geom]` tuple used to compute classification when `classify` is `undef`.
-function ps_face_sites(poly, inter_radius = 1, edge_len = undef, classify = undef, classify_opts = undef) =
+function _ps_face_sites_from_base(base) =
     let(
-        exp_edge_len = is_undef(edge_len) ? inter_radius * poly_e_over_ir(poly) : edge_len,
+        poly = _ps_placement_base_poly(base),
+        exp_edge_len = _ps_placement_base_edge_len(base),
         scale = exp_edge_len,
-        verts = poly_verts(poly),
-        faces = poly_faces(poly),
-        faces0 = ps_orient_all_faces_outward(verts, faces),
-        edges = _ps_edges_from_faces(faces0),
-        edge_faces = ps_edge_faces_table(faces0, edges),
-        face_n = [ for (f = faces0) ps_face_frame_normal(verts, f) ],
-        cls = _ps_resolve_classify(poly, classify, classify_opts),
-        family_counts = is_undef(cls) ? undef : ps_classify_counts(cls),
+        verts = _ps_placement_base_verts(base),
+        faces = _ps_placement_base_faces(base),
+        faces0 = _ps_placement_base_faces_oriented(base),
+        edges = _ps_placement_base_edges(base),
+        edge_faces = _ps_placement_base_edge_faces(base),
+        face_n = _ps_placement_base_face_normals(base),
+        cls = _ps_placement_base_classify(base),
+        family_counts = _ps_placement_base_family_counts(base),
         face_family_ids = is_undef(cls) ? [] : ps_classify_face_ids(cls, len(faces)),
         edge_family_count = is_undef(family_counts) ? undef : family_counts[1],
         vert_family_count = is_undef(family_counts) ? undef : family_counts[2]
@@ -1125,23 +1192,23 @@ function ps_face_sites(poly, inter_radius = 1, edge_len = undef, classify = unde
                 face_neighbors_idx = _ps_face_site_neighbors_idx(f, fi, faces0, edges, edge_faces),
                 face_dihedrals = _ps_face_site_dihedrals(f, fi, faces0, edges, edge_faces, face_n)
             )
-    [
-        fi,
-        exp_edge_len,
-        len(face_pts2d),
-        face_midradius,
-        face_radius,
-        face_planarity_err,
-        face_planarity_err <= 1e-8,
-        is_undef(cls) ? undef : face_family_ids[fi],
-        is_undef(family_counts) ? undef : family_counts[0],
-        edge_family_count,
-        vert_family_count,
-        frame,
-        ps_face_local_context(
-            face_pts3d_local,
-            face_pts2d,
-            fi,
+            [
+                fi,
+                exp_edge_len,
+                len(face_pts2d),
+                face_midradius,
+                face_radius,
+                face_planarity_err,
+                face_planarity_err <= 1e-8,
+                is_undef(cls) ? undef : face_family_ids[fi],
+                is_undef(family_counts) ? undef : family_counts[0],
+                edge_family_count,
+                vert_family_count,
+                frame,
+                ps_face_local_context(
+                    face_pts3d_local,
+                    face_pts2d,
+                    fi,
                     faces,
                     poly_verts_local,
                     face_neighbors_idx,
@@ -1150,6 +1217,9 @@ function ps_face_sites(poly, inter_radius = 1, edge_len = undef, classify = unde
                 )
             ]
     ];
+
+function ps_face_sites(poly, inter_radius = 1, edge_len = undef, classify = undef, classify_opts = undef) =
+    _ps_face_sites_from_base(_ps_placement_base(poly, inter_radius, edge_len, classify, classify_opts));
 
 // Module: place_on_faces()
 // Usage:
@@ -1698,18 +1768,16 @@ module _ps_place_on_face_foreign_proxy_volume_group_hull(group, group_idx, group
 //   edge_len = explicit target edge length; overrides `inter_radius`.
 //   classify = optional `poly_classify(...)` result to reuse for family ids.
 //   classify_opts = optional `[detail, eps, radius, include_geom]` tuple used to compute classification when `classify` is `undef`.
-function ps_edge_sites(poly, inter_radius = 1, edge_len = undef, classify = undef, classify_opts = undef) =
+function _ps_edge_sites_from_base(base) =
     let(
-        exp_edge_len = is_undef(edge_len) ? inter_radius * poly_e_over_ir(poly) : edge_len,
+        exp_edge_len = _ps_placement_base_edge_len(base),
         scale = exp_edge_len,
-        verts = poly_verts(poly),
-        faces = poly_faces(poly),
-        faces0 = ps_orient_all_faces_outward(verts, faces),
-        edges = _ps_edges_from_faces(faces),
-        edge_faces = ps_edge_faces_table(faces0, edges),
-        face_n = [for (f = faces0) ps_face_frame_normal(verts, f)],
-        cls = _ps_resolve_classify(poly, classify, classify_opts),
-        family_counts = is_undef(cls) ? undef : ps_classify_counts(cls),
+        verts = _ps_placement_base_verts(base),
+        edges = _ps_placement_base_edges(base),
+        edge_faces = _ps_placement_base_edge_faces(base),
+        face_n = _ps_placement_base_face_normals(base),
+        cls = _ps_placement_base_classify(base),
+        family_counts = _ps_placement_base_family_counts(base),
         edge_family_ids = is_undef(cls) ? [] : ps_classify_edge_ids(cls, len(edges)),
         face_family_count = is_undef(family_counts) ? undef : family_counts[0],
         edge_family_count = is_undef(family_counts) ? undef : family_counts[1],
@@ -1766,6 +1834,9 @@ function ps_edge_sites(poly, inter_radius = 1, edge_len = undef, classify = unde
                 frame
             ]
     ];
+
+function ps_edge_sites(poly, inter_radius = 1, edge_len = undef, classify = undef, classify_opts = undef) =
+    _ps_edge_sites_from_base(_ps_placement_base(poly, inter_radius, edge_len, classify, classify_opts));
 
 // Function: ps_vertex_sites()
 // Usage:
@@ -1891,7 +1962,7 @@ module place_on_vertices(poly, inter_radius = 1, edge_len = undef, classify = un
 
 // Module: place_on_edges()
 // Usage:
-//   place_on_edges(poly, inter_radius, edge_len, classify, classify_opts, indices);
+//   place_on_edges(poly, inter_radius, edge_len, classify, classify_opts, indices, edge_regions, edge_region_eps);
 // Description:
 //   Place children on selected edges of a polyhedron.
 //   .
@@ -1905,8 +1976,14 @@ module place_on_vertices(poly, inter_radius = 1, edge_len = undef, classify = un
 //   classify = optional `poly_classify(...)` result to reuse for family ids.
 //   classify_opts = optional `[detail, eps, radius, include_geom]` tuple used to compute classification when `classify` is `undef`.
 //   indices = `undef` for all edges, one edge index, or a list of edge indices.
-module place_on_edges(poly, inter_radius = 1, edge_len = undef, classify = undef, classify_opts = undef, indices = undef) {
-    sites = ps_edge_sites(poly, inter_radius, edge_len, classify, classify_opts);
+//   edge_regions = true to precompute the internal edge-region context used by `ps_current_edge_region_*` helpers.
+//   edge_region_eps = tolerance used when deriving edge-region face boundary spans.
+module place_on_edges(poly, inter_radius = 1, edge_len = undef, classify = undef, classify_opts = undef, indices = undef, edge_regions = false, edge_region_eps = 1e-8) {
+    base = _ps_placement_base(poly, inter_radius, edge_len, classify, classify_opts);
+    sites = _ps_edge_sites_from_base(base);
+    edge_region_ctx = edge_regions
+        ? _ps_edge_region_context_from_sites(sites, _ps_face_sites_from_base(base), edge_region_eps)
+        : undef;
 
     for (site = sites) {
         if (_ps_place_idx_selected(ps_edge_site_idx(site), indices)) {
@@ -1924,6 +2001,7 @@ module place_on_edges(poly, inter_radius = 1, edge_len = undef, classify = undef
             $ps_edge_family_count   = ps_edge_site_edge_family_count(site);
             $ps_vertex_family_count = ps_edge_site_vertex_family_count(site);
             $ps_edge_frame          = ps_edge_site_frame(site);
+            $_ps_edge_region_context = edge_region_ctx;
 
             multmatrix(ps_placement_frame_matrix($ps_edge_frame))
                 children();

--- a/src/tests/core/TestEdgeRegions.scad
+++ b/src/tests/core/TestEdgeRegions.scad
@@ -172,6 +172,18 @@ module test_ps_edge_region_shells_from_context__matches_oneoff_crossing_wedges()
     }
 }
 
+module test_ps_current_edge_region_shells__matches_explicit_context() {
+    p = poly_truncate(tetrahedron(), t = -1);
+    ctx = ps_edge_region_context(p, inter_radius = 26);
+
+    place_on_edges(p, inter_radius = 26, indices = 0, edge_regions = true) {
+        current = ps_current_edge_region_shells(outset = 1.4, z0 = -1.2, z1 = 2);
+        explicit = ps_edge_region_shells_from_context(ctx, outset = 1.4, z0 = -1.2, z1 = 2, edge_idx = $ps_edge_idx);
+
+        assert_shells_equivalent(current, explicit, "current edge-region helper should use placement context");
+    }
+}
+
 module run_TestEdgeRegions() {
     echo("Running TestEdgeRegions...");
     test_ps_edge_region_shells__tetra_edge_single_atom();
@@ -183,6 +195,7 @@ module run_TestEdgeRegions() {
     test_ps_edge_region_shells__crossing_constraints_are_split_at_crossing_z();
     test_ps_edge_region_shells_from_context__matches_oneoff_tetra();
     test_ps_edge_region_shells_from_context__matches_oneoff_crossing_wedges();
+    test_ps_current_edge_region_shells__matches_explicit_context();
     echo("TestEdgeRegions passed");
 }
 

--- a/src/tests/core/TestEdgeRegions.scad
+++ b/src/tests/core/TestEdgeRegions.scad
@@ -30,6 +30,32 @@ function _test_shell_points_are_finite(points) =
                 1
     ]) == len(points);
 
+function _test_shell_max_point_delta(a, b) =
+    let(
+        pts_a = ps_loop_shell_points(a),
+        pts_b = ps_loop_shell_points(b)
+    )
+    max(concat(
+        [0],
+        [
+            for (i = [0:1:len(pts_a)-1])
+                for (axis = [0:1:2])
+                    abs(pts_a[i][axis] - pts_b[i][axis])
+        ]
+    ));
+
+module assert_shells_equivalent(a, b, msg="") {
+    assert_int_eq(len(a), len(b), str(msg, " shell count"));
+
+    for (i = [0:1:len(a)-1]) {
+        assert_int_eq(ps_loop_shell_source_idx(a[i]), ps_loop_shell_source_idx(b[i]), str(msg, " shell source idx i=", i));
+        assert(ps_loop_shell_source_kind(a[i]) == ps_loop_shell_source_kind(b[i]), str(msg, " shell source kind i=", i));
+        assert(ps_loop_shell_faces(a[i]) == ps_loop_shell_faces(b[i]), str(msg, " shell faces i=", i));
+        assert_int_eq(len(ps_loop_shell_points(a[i])), len(ps_loop_shell_points(b[i])), str(msg, " shell point count i=", i));
+        assert(_test_shell_max_point_delta(a[i], b[i]) <= EPS, str(msg, " shell point coords i=", i));
+    }
+}
+
 module test_ps_edge_region_shells__tetra_edge_single_atom() {
     p = tetrahedron();
     shells = ps_edge_region_shells(p, outset = 0.4, z0 = -0.3, z1 = 0.6, inter_radius = 12, edge_idx = 0);
@@ -124,6 +150,28 @@ module test_ps_edge_region_shells__crossing_constraints_are_split_at_crossing_z(
     assert_near(ranges[1][0], 0.4, EPS, "second split should start at crossing z");
 }
 
+module test_ps_edge_region_shells_from_context__matches_oneoff_tetra() {
+    p = tetrahedron();
+    ctx = ps_edge_region_context(p, inter_radius = 12);
+    oneoff = ps_edge_region_shells(p, outset = 0.4, z0 = -0.3, z1 = 0.6, inter_radius = 12, edge_idx = 0);
+    cached = ps_edge_region_shells_from_context(ctx, outset = 0.4, z0 = -0.3, z1 = 0.6, edge_idx = 0);
+
+    assert_shells_equivalent(cached, oneoff, "tetra context path should match oneoff path");
+}
+
+module test_ps_edge_region_shells_from_context__matches_oneoff_crossing_wedges() {
+    p = poly_truncate(tetrahedron(), t = -1);
+    ctx = ps_edge_region_context(p, inter_radius = 26);
+    edge_count = len(ps_edge_sites(p));
+
+    for (ei = [0:1:edge_count-1]) {
+        oneoff = ps_edge_region_shells(p, outset = 1.4, z0 = -1.2, z1 = 2, inter_radius = 26, edge_idx = ei);
+        cached = ps_edge_region_shells_from_context(ctx, outset = 1.4, z0 = -1.2, z1 = 2, edge_idx = ei);
+
+        assert_shells_equivalent(cached, oneoff, str("crossing context path should match oneoff path edge=", ei));
+    }
+}
+
 module run_TestEdgeRegions() {
     echo("Running TestEdgeRegions...");
     test_ps_edge_region_shells__tetra_edge_single_atom();
@@ -133,6 +181,8 @@ module run_TestEdgeRegions() {
     test_ps_edge_region_shells__crossing_wedges_are_lhr_outward();
     test_ps_edge_region_shells__side_constraints_preserve_identity();
     test_ps_edge_region_shells__crossing_constraints_are_split_at_crossing_z();
+    test_ps_edge_region_shells_from_context__matches_oneoff_tetra();
+    test_ps_edge_region_shells_from_context__matches_oneoff_crossing_wedges();
     echo("TestEdgeRegions passed");
 }
 

--- a/src/tests/regression/cases/edge_regions/edge_region_volumes.scad
+++ b/src/tests/regression/cases/edge_regions/edge_region_volumes.scad
@@ -38,17 +38,15 @@ module _edge_region_wire(poly) {
             cube([$ps_edge_len, 0.45, 0.45], center = true);
 }
 
-module _edge_region_atoms(poly, ctx) {
+module _edge_region_atoms(poly) {
     color("indianred", 0.70)
-        place_on_edges(poly, IR)
-            ps_edge_region_volume_from_context(ctx, outset = OUTSET, z0 = Z0, z1 = Z1);
+        place_on_edges(poly, IR, edge_regions = true)
+            ps_current_edge_region_volume(outset = OUTSET, z0 = Z0, z1 = Z1);
 }
 
 module _edge_region_panel(poly, label_s) {
-    ctx = ps_edge_region_context(poly, inter_radius = IR);
-
     _edge_region_wire(poly);
-    _edge_region_atoms(poly, ctx);
+    _edge_region_atoms(poly);
     reg_panel_label(label_s);
 }
 

--- a/src/tests/regression/cases/edge_regions/edge_region_volumes.scad
+++ b/src/tests/regression/cases/edge_regions/edge_region_volumes.scad
@@ -38,15 +38,17 @@ module _edge_region_wire(poly) {
             cube([$ps_edge_len, 0.45, 0.45], center = true);
 }
 
-module _edge_region_atoms(poly) {
+module _edge_region_atoms(poly, ctx) {
     color("indianred", 0.70)
         place_on_edges(poly, IR)
-            ps_edge_region_volume(poly, outset = OUTSET, z0 = Z0, z1 = Z1, inter_radius = IR);
+            ps_edge_region_volume_from_context(ctx, outset = OUTSET, z0 = Z0, z1 = Z1);
 }
 
 module _edge_region_panel(poly, label_s) {
+    ctx = ps_edge_region_context(poly, inter_radius = IR);
+
     _edge_region_wire(poly);
-    _edge_region_atoms(poly);
+    _edge_region_atoms(poly, ctx);
     reg_panel_label(label_s);
 }
 


### PR DESCRIPTION
Changed:

  - Added shared placement base computation in placement.scad.
  - Updated ps_face_sites(...) and ps_edge_sites(...) to reuse that base.
  - Added place_on_edges(..., edge_regions=true, edge_region_eps=...).
  - Added ps_current_edge_region_shells(...) and ps_current_edge_region_volume(...).
  - Switched the edge-region example and regression case to the new current-edge API.
  - Added a focused test proving current helper output matches explicit cached context output.
  - Updated placement/API docs for the new edge-region path.