### PR TITLE
[#274] Skip vertex-fan clipping when source face loop is self-crossing

### DIFF
--- a/docs/design/face_regions.md
+++ b/docs/design/face_regions.md
@@ -127,12 +127,14 @@ XY offset, which is simpler for inspection but produces different physical gaps
 for different side wall angles.
 
 After the edge-span inset is applied, source-vertex corners with valence
-greater than three get an extra projected clip line. The clip direction comes
-from the corresponding side of the local vertex figure for the current source
-face. Its position is measured from the already-inset adjacent-edge miter
-farther into the filled region. This keeps the vertex clip compatible with the
-edge-span inset instead of reusing the original source vertex as the clip
-origin.
+greater than three on simple source-face loops get an extra projected clip
+line. The clip direction comes from the corresponding side of the local vertex
+figure for the current source face. Its position is measured from the
+already-inset adjacent-edge miter farther into the filled region. This keeps
+the vertex clip compatible with the edge-span inset instead of reusing the
+original source vertex as the clip origin. Self-crossing source faces skip this
+vertex-fan clip and use only their boundary spans, because a true source vertex
+can participate in multiple filled-loop semantics after arrangement splitting.
 
 The anti-interference direction is the bisector between a selected current-face
 ray and the adjacent-face ray on the current face `+Z` branch. For filled atoms
@@ -172,5 +174,6 @@ geometry is replayed and subtracted deliberately.
 - Each filled boundary loop becomes one shell. Do not rely on holed cap faces;
   use multiple shells for multiple loops.
 - The shell is an admissible region, not a finished printable face plate.
-- Vertex-fan clipping is applied at true source-vertex corners only. Generated
-  self-crossing split points still use only their projected boundary spans.
+- Vertex-fan clipping is applied at true source-vertex corners on simple source
+  face loops only. Self-crossing source faces and generated self-crossing split
+  points still use only their projected boundary spans.

--- a/src/polysymmetrica/core/face_regions.scad
+++ b/src/polysymmetrica/core/face_regions.scad
@@ -526,8 +526,11 @@ function _ps_fr_vertex_clip_specs(poly_faces_idx, poly_verts_local, edges, edge_
     (boundary_inset <= eps) ? undef :
     let(
         face = poly_faces_idx[face_idx],
+        face_pts2d = ps_xy([for (vi = face) poly_verts_local[vi]]),
+        face_self_crosses = len(_ps_fr_loop_self_hits(face_pts2d, eps)) > 0,
         n = len(loop_sites)
     )
+    face_self_crosses ? undef :
     [
         for (i = [0:1:n-1])
             let(

--- a/src/tests/core/TestFaceRegions.scad
+++ b/src/tests/core/TestFaceRegions.scad
@@ -57,9 +57,21 @@ function _test_loop_self_hits(loop, eps=EPS) =
                         [i, j]
     ];
 
+function _test_loop_adjacent_duplicate_idxs(loop, eps=EPS) =
+    let(n = len(loop))
+    [
+        for (i = [0:1:n-1])
+            if (norm(loop[(i + 1) % n] - loop[i]) <= eps)
+                i
+    ];
+
 function _test_shell_caps_are_simple(shell, eps=EPS) =
     len(_test_loop_self_hits(ps_loop_shell_bottom_loop2d(shell), eps)) == 0
         && len(_test_loop_self_hits(ps_loop_shell_top_loop2d(shell), eps)) == 0;
+
+function _test_shell_caps_have_no_adjacent_duplicates(shell, eps=EPS) =
+    len(_test_loop_adjacent_duplicate_idxs(ps_loop_shell_bottom_loop2d(shell), eps)) == 0
+        && len(_test_loop_adjacent_duplicate_idxs(ps_loop_shell_top_loop2d(shell), eps)) == 0;
 
 function _test_first_face_idx_by_n(poly, n, i=0) =
     (i >= len(poly_faces(poly))) ? undef :
@@ -277,6 +289,17 @@ module test_ps_face_region_loop_shells__pentagram_zmax_expands_outward() {
     assert(_test_shell_caps_are_simple(shells[0]), "pentagram shell cap loops should be simple");
 }
 
+module test_ps_face_region_loop_shells__star_antiprism_vertex_clips_drop_duplicate_cap_points() {
+    p = poly_antiprism(5, p = 3, angle = 0);
+    site = _test_face_site(p, 0);
+    face_ctx = ps_face_site_face_local_context(site);
+    shells = ps_face_region_loop_shells(face_ctx, -0.8, 0.5, max_project = 10, boundary_inset = 1.1);
+
+    assert_int_eq(len(shells), 1, "star antiprism face should produce one shell");
+    assert(_test_shell_caps_are_simple(shells[0]), "star antiprism clipped cap loops should be simple");
+    assert(_test_shell_caps_have_no_adjacent_duplicates(shells[0]), "star antiprism clipped cap loops should not expose adjacent duplicate vertices");
+}
+
 module test_ps_face_region_loop_shells__zero_winding_exposure_uses_same_winding_fallback() {
     zero_cell_site = [0, undef, 0, undef, 0, undef, 0, 1, "source_edge", 0];
 
@@ -393,6 +416,7 @@ module run_TestFaceRegions() {
     test_ps_face_region_loop_shells__side_inset_compensates_face_offset();
     test_ps_face_region_loop_shells__matches_boundary_loop_count();
     test_ps_face_region_loop_shells__pentagram_zmax_expands_outward();
+    test_ps_face_region_loop_shells__star_antiprism_vertex_clips_drop_duplicate_cap_points();
     test_ps_face_region_loop_shells__zero_winding_exposure_uses_same_winding_fallback();
     test_ps_face_region_loop_shells__anti_tet_hex_is_finite();
     test_ps_face_region_loop_shells__anti_tet_winding_splits_exposure();


### PR DESCRIPTION
Diagnosis: #209’s high-valence vertex-fan clipping was being applied to a self-crossing star cap. For poly_antiprism(n=5, p=3, angle=0) face 0, that inserted adjacent duplicate cap points into the face-region shell. The raw shell rendered, but face_plate’s top-skin extrusion over that duplicate-containing loop triggered OpenSCAD’s NotManifold repair.

  I changed ps_face_region_loop_shells to skip vertex-fan clipping when the source face loop is self-crossing, leaving those cases to the boundary-span arrangement only. Added a focused test for the star antiprism face, and updated docs/design/face_regions.md to document the boundary.