### PR TITLE
[#255] Cantellation modes

### DIFF
--- a/docs/guides/cantellation.md
+++ b/docs/guides/cantellation.md
@@ -4,24 +4,33 @@ This document captures current cantellation behavior, parameterization, and solv
 
 ## Parameterization
 
-`poly_cantellate(poly, df=undef, c=undef, df_max=undef, steps=16, family_edge_idx=0, eps, len_eps)`
+`poly_cantellate(poly, df=undef, c=undef, df_max=undef, steps=16, family_edge_idx=0, eps, len_eps, profile=undef, cleanup=false, cleanup_eps=1e-8, style="strict", cap_mode=undef)`
 
 - **df** controls face offsets (how far original faces move along their normals).
 - **c** provides a normalized knob; `c=0.5` targets square edge faces (via `solve_cantellate_square_df`).
 - If `df` is omitted, `c` (or a default `c=0.5`) is used to derive a `df`.
 - `df_max` bounds the normalized mapping; `steps` controls the square‑target search.
+- **style** controls vertex-cap topology:
+  - `"strict"` preserves the classic shared-incidence construction.
+  - `"planarized"` keeps source/edge sites unchanged, then adds separate
+    planarized vertex-cap sites and connector quads.
+- **cap_mode** is only valid with `style="planarized"` and uses the shared
+  vertex-figure realization modes: `"planar_edge_fraction"`,
+  `"edge_fraction"`, `"centric"`, and `"poly_centroidal"`.
 
-Topology (current):
+Topology:
 - Face cycles: original faces (expanded) become larger polygons.
 - Edge cycles: quads derived from each original edge.
 - Vertex cycles: polygons derived from each original vertex (valence‑gons).
+- Planarized connector cycles: one quad per source `(vertex, incident face)`
+  side, bridging the strict raw incidence loop to the realized cap loop.
 
 ## Components & Current Limitations
 
 Cantellation is constructed from three components:
 
 1) **Face cycles**
-   - Derived by shifting original face planes by `df` and intersecting with edge‑bisector planes.
+   - Derived by shifting each original face corner along that face's normal by `df`.
    - Intended to remain planar by construction.
 
 2) **Edge cycles** (quads)
@@ -30,9 +39,12 @@ Cantellation is constructed from three components:
 
 3) **Vertex cycles** (valence‑gons)
    - Built from edge‑adjacent points around each original vertex.
+   - In strict mode, they share the source/edge incidence points directly.
+   - In planarized mode, they use separate realized cap points.
 
 Current limitations:
-- Mixed‑family bases can show slight warping depending on how offsets are balanced.
+- Strict vertex caps can be non-planar for irregular or valence > 3 source
+  vertices.
 - Extreme offsets (large `df`) can yield self‑intersections or degenerate faces; use with care.
 
 ## Solvers / Helpers
@@ -40,7 +52,7 @@ Current limitations:
 - `solve_cantellate_square_df(poly, df_min, df_max, steps, family_edge_idx, eps)`
   - Searches for a `df` that makes a chosen edge‑family as square as possible.
 
-- `poly_cantellate_norm(poly, c, df_max=undef, steps=16, family_edge_idx=0, eps, len_eps)`
+- `poly_cantellate_norm(poly, c, df_max=undef, steps=16, family_edge_idx=0, eps, len_eps, profile=undef, cleanup=false, cleanup_eps=1e-8, style="strict", cap_mode=undef)`
   - Normalized cantellation (maps `c in [0,1]` to a `df` range).
   - Intended as the user‑friendly entry point for many examples.
 
@@ -58,6 +70,11 @@ p = poly_cantellate(hexahedron(), df = 0.2);
 ### Normalized cantellation
 ```
 p = poly_cantellate_norm(hexahedron(), 0.5);
+```
+
+### Planarized vertex caps
+```
+p = poly_cantellate(base, df = 0.1, style = "planarized");
 ```
 
 ### Square‑targeted face family

--- a/docs/guides/profile.md
+++ b/docs/guides/profile.md
@@ -23,7 +23,7 @@ Rows can target all elements, families, or explicit element indices.
 
 - `kind` is usually `"face"`, `"vert"`, `"edge"` (operators may define others)
 - `id_or_ids` can be a single index or a list of indices
-- keys are operator-defined (e.g. `df`, `angle`, `c`, `de`, `t`)
+- keys are operator-defined (e.g. `df`, `angle`, `c`, `de`, `t`, `cap_mode`)
 - each row can set **multiple keys** for the same target
 
 Example with multiple params per row:
@@ -33,6 +33,7 @@ profile = [
     ["face", "all",    ["angle", 15], ["df", 0.03]],
     ["face", "family", 1, ["angle", 20], ["df", 0.04]],
     ["vert", "family", 0, ["c", 0.06], ["de", 0.05]],
+    ["vert", "id", 3, ["cap_mode", "centric"]],
     ["face", "id", [2, 7], ["angle", 19]]
 ];
 ```

--- a/src/polysymmetrica/core/truncation.scad
+++ b/src/polysymmetrica/core/truncation.scad
@@ -796,14 +796,82 @@ function _ps_cantellate_df_from_c(poly, c, df_max=undef, steps=16, family_edge_i
     )
     _ps_cantellate_df_from_c_linear(c, df_mid, df_max_eff);
 
+function _ps_cantellate_face_site_idx(face_offsets, fi, pos) =
+    face_offsets[fi] + pos;
+
+function _ps_cantellate_cap_site_idx(face_offsets, cap_site_offset, fi, pos) =
+    cap_site_offset + face_offsets[fi] + pos;
+
+function _ps_cantellate_vertex_raw_pts(face_pts, faces0, fan_faces, vi) =
+    [
+        for (fi = fan_faces)
+            let(pos = _ps_index_of(faces0[fi], vi))
+                face_pts[fi][pos]
+    ];
+
+function _ps_cantellate_cap_pts_by_vertex(verts0, faces0, face_pts, edges, edge_faces, poly0, cap_mode_by_vert, poly_center, eps) =
+    [
+        for (vi = [0:1:len(verts0)-1])
+            let(
+                fan_faces = ps_vertex_fan_faces_idx(ps_vertex_fan(poly0, vi, edges, edge_faces)),
+                raw_pts = _ps_cantellate_vertex_raw_pts(face_pts, faces0, fan_faces, vi)
+            )
+            ps_vertex_figure_points_from_raw(verts0[vi], raw_pts, cap_mode_by_vert[vi], poly_center, eps)
+    ];
+
+function _ps_cantellate_cap_pts_by_face(verts0, faces0, edges, edge_faces, poly0, cap_pts_by_vertex) =
+    [
+        for (fi = [0:1:len(faces0)-1])
+            [
+                for (v = faces0[fi])
+                    let(
+                        fan_faces = ps_vertex_fan_faces_idx(ps_vertex_fan(poly0, v, edges, edge_faces)),
+                        fan_pos = _ps_index_of(fan_faces, fi)
+                    )
+                    cap_pts_by_vertex[v][fan_pos]
+            ]
+    ];
+
+function _ps_cantellate_vertex_connector_cycles(verts0, faces0, edges, edge_faces, poly0, face_offsets, cap_site_offset) =
+    [
+        for (vi = [0:1:len(verts0)-1])
+            let(
+                fan_faces = ps_vertex_fan_faces_idx(ps_vertex_fan(poly0, vi, edges, edge_faces)),
+                n = len(fan_faces)
+            )
+            for (i = [0:1:n-1])
+                let(
+                    fi0 = fan_faces[i],
+                    fi1 = fan_faces[(i + 1) % n],
+                    pos0 = _ps_index_of(faces0[fi0], vi),
+                    pos1 = _ps_index_of(faces0[fi1], vi)
+                )
+                [
+                    [1, _ps_cantellate_face_site_idx(face_offsets, fi0, pos0)],
+                    [1, _ps_cantellate_face_site_idx(face_offsets, fi1, pos1)],
+                    [1, _ps_cantellate_cap_site_idx(face_offsets, cap_site_offset, fi1, pos1)],
+                    [1, _ps_cantellate_cap_site_idx(face_offsets, cap_site_offset, fi0, pos0)]
+                ]
+    ];
+
 // Function: poly_cantellate()
 // Usage:
 //   result = poly_cantellate(poly, df=undef, c=undef, df_max=undef, steps=16,
 //       family_edge_idx=0, eps=1e-8, len_eps=1e-6, profile=undef,
-//       cleanup=false, cleanup_eps=1e-8);
+//       cleanup=false, cleanup_eps=1e-8, style="strict", cap_mode=undef);
 // Description:
 //   Cantellate or expand a poly. When `df` is omitted, `c` is mapped onto a
 //   face offset using the square-edge calibration map.
+//   .
+//   `style="strict"` preserves the classic shared-incidence topology: each
+//   `(source face, source vertex)` point is shared by source faces, edge faces,
+//   and vertex caps. This is watertight but vertex caps can be non-planar for
+//   irregular or valence > 3 source vertices.
+//   .
+//   `style="planarized"` keeps the shared source/edge sites unchanged, then
+//   creates separate vertex-cap sites using the shared vertex-figure
+//   realization modes. Connector quads bridge each raw incidence loop to its
+//   planarized cap loop.
 // Arguments:
 //   poly = source poly descriptor.
 //   df = explicit outward face offset used to build the expanded face planes. When supplied, it is used directly unless a profile row overrides it.
@@ -813,9 +881,11 @@ function _ps_cantellate_df_from_c(poly, c, df_max=undef, steps=16, family_edge_i
 //   family_edge_idx = representative source edge-family index used to choose which edge faces should become square at `c=0.5`.
 //   eps = geometric tolerance for transform construction.
 //   len_eps = point-merging tolerance for generated vertices.
-//   profile = optional face profile rows supporting `["df", value]` and `["c", value]` overrides.
+//   profile = optional face profile rows supporting `["df", value]` and `["c", value]` overrides, plus vertex `["cap_mode", value]` rows when `style="planarized"`.
 //   cleanup = whether to run structural cleanup on the result.
 //   cleanup_eps = cleanup tolerance used when `cleanup=true`.
+//   style = `"strict"` or `"planarized"` topology.
+//   cap_mode = vertex-cap realization mode for `style="planarized"`; defaults to `"planar_edge_fraction"` there and must be omitted for strict cantellation.
 function poly_cantellate(
     poly,
     df=undef,
@@ -827,11 +897,14 @@ function poly_cantellate(
     len_eps = 1e-6,
     profile=undef,
     cleanup=false,
-    cleanup_eps=1e-8
+    cleanup_eps=1e-8,
+    style="strict",
+    cap_mode=undef
 ) =
     let(
         rows = is_undef(profile) ? [] : profile,
-        _pwarn = _ps_override_warn_unsupported(rows, "poly_cantellate", [["face", ["df", "c"]]])
+        _style_ok = assert(style == "strict" || style == "planarized", "poly_cantellate: style must be \"strict\" or \"planarized\""),
+        _pwarn = _ps_override_warn_unsupported(rows, "poly_cantellate", [["face", ["df", "c"]], ["vert", ["cap_mode"]]])
     )
     let(
         base = _ps_poly_base(poly),
@@ -841,15 +914,32 @@ function poly_cantellate(
         edge_faces = base[3],
         face_n = base[4],
         poly0 = base[5],
-        face_fid = (len(rows) > 0 && ps_profile_uses_family(rows, "face"))
-            ? ps_classify_face_ids(poly_classify(poly, 1, 1e-6, 1, false), len(faces0))
+        need_face_fid = (len(rows) > 0 && ps_profile_uses_family(rows, "face")),
+        need_vert_fid = (len(rows) > 0 && ps_profile_uses_family(rows, "vert")),
+        cls = (need_face_fid || need_vert_fid) ? poly_classify(poly, 1, 1e-6, 1, false) : undef,
+        face_fid = need_face_fid
+            ? ps_classify_face_ids(cls, len(faces0))
+            : undef,
+        vert_fid = need_vert_fid
+            ? ps_classify_vert_ids(cls, len(verts0))
             : undef,
         params_compiled = (len(rows) == 0) ? undef : ps_profile_compile_specs(rows, [
             ["face", "df", len(faces0), face_fid],
-            ["face", "c", len(faces0), face_fid]
+            ["face", "c", len(faces0), face_fid],
+            ["vert", "cap_mode", len(verts0), vert_fid]
         ]),
         face_df_by_idx = is_undef(params_compiled) ? undef : params_compiled[0],
         face_c_by_idx = is_undef(params_compiled) ? undef : params_compiled[1],
+        vert_cap_mode_by_idx = is_undef(params_compiled) ? undef : params_compiled[2],
+        has_cap_mode_rows = !is_undef(vert_cap_mode_by_idx) && len([for (x = vert_cap_mode_by_idx) if (!is_undef(x)) 1]) > 0,
+        _strict_cap_ok = assert(style == "planarized" || (is_undef(cap_mode) && !has_cap_mode_rows), "poly_cantellate: cap_mode requires style=\"planarized\""),
+        cap_mode_default = is_undef(cap_mode) ? "planar_edge_fraction" : cap_mode,
+        cap_mode_by_vert = [
+            for (vi = [0:1:len(verts0)-1])
+                let(mode_ov = ps_compiled_param_get(vert_cap_mode_by_idx, vi))
+                is_undef(mode_ov) ? cap_mode_default : mode_ov
+        ],
+        _cap_modes_ok = (style == "planarized") ? _ps_truncate_cap_modes_ok(cap_mode_by_vert) : 0,
         has_c_overrides = !is_undef(face_c_by_idx) && (len([for (x = face_c_by_idx) if (!is_undef(x)) 1]) > 0),
         need_c_map = is_undef(df) || !is_undef(c) || has_c_overrides,
         cmap = need_c_map ? _ps_cantellate_df_map(poly, df_max, steps, family_edge_idx) : undef,
@@ -872,16 +962,26 @@ function poly_cantellate(
         // offset face corners: one point per (face, vertex) incidence
         face_pts = _ps_face_offset_pts(verts0, faces0, face_n, df_by_face),
         face_offsets = _ps_face_offsets(faces0),
+        face_pts_flat = [for (fi = [0:1:len(faces0)-1]) for (p = face_pts[fi]) p],
+        cap_site_offset = len(face_pts_flat),
+        cap_pts_by_vertex = (style == "planarized")
+            ? _ps_cantellate_cap_pts_by_vertex(verts0, faces0, face_pts, edges, edge_faces, poly0, cap_mode_by_vert, v_sum(verts0) / len(verts0), eps)
+            : undef,
+        cap_pts = (style == "planarized")
+            ? _ps_cantellate_cap_pts_by_face(verts0, faces0, edges, edge_faces, poly0, cap_pts_by_vertex)
+            : undef,
+        cap_pts_flat = (style == "planarized")
+            ? [for (fi = [0:1:len(faces0)-1]) for (p = cap_pts[fi]) p]
+            : [],
         sites = [
             for (fi = [0:1:len(faces0)-1])
                 for (v = faces0[fi])
                     [fi, v]
         ],
-        site_points = [
-            for (fi = [0:1:len(faces0)-1])
-                for (p = face_pts[fi])
-                    p
-        ],
+        cap_sites = (style == "planarized")
+            ? [for (fi = [0:1:len(faces0)-1]) for (v = faces0[fi]) ["cap", fi, v]]
+            : [],
+        site_points = concat(face_pts_flat, cap_pts_flat),
         face_cycles = [
             for (fi = [0:1:len(faces0)-1])
                 let(n = len(faces0[fi]))
@@ -914,12 +1014,17 @@ function poly_cantellate(
                 [
                     for (fi = fc)
                         let(pos = _ps_index_of(faces0[fi], vi))
-                            [1, face_offsets[fi] + pos]
+                            [1, (style == "planarized")
+                                ? _ps_cantellate_cap_site_idx(face_offsets, cap_site_offset, fi, pos)
+                                : _ps_cantellate_face_site_idx(face_offsets, fi, pos)]
                 ]
         ],
-        cycles_all = concat(face_cycles, edge_cycles, vert_cycles)
+        connector_cycles = (style == "planarized")
+            ? _ps_cantellate_vertex_connector_cycles(verts0, faces0, edges, edge_faces, poly0, face_offsets, cap_site_offset)
+            : [],
+        cycles_all = concat(face_cycles, edge_cycles, connector_cycles, vert_cycles)
     )
-    let(q = ps_poly_transform_from_sites(verts0, sites, site_points, cycles_all, eps, len_eps))
+    let(q = ps_poly_transform_from_sites(verts0, concat(sites, cap_sites), site_points, cycles_all, eps, len_eps))
     ps_finalize_poly(q, cleanup, cleanup_eps);
 
 // Measure how square an edge face is (edge length spread).
@@ -986,7 +1091,7 @@ function solve_cantellate_square_df(poly, df_min, df_max, steps=40, family_edge_
 // Usage:
 //   result = poly_cantellate_norm(poly, c, df_max=undef, steps=16,
 //       family_edge_idx=0, eps=1e-8, len_eps=1e-6, profile=undef,
-//       cleanup=false, cleanup_eps=1e-8);
+//       cleanup=false, cleanup_eps=1e-8, style="strict", cap_mode=undef);
 // Description:
 //   Cantellate a poly using normalized control `c in [0,1]`, mapped onto `df`
 //   so that `c=0.5` hits the computed square-edge offset.
@@ -1001,6 +1106,8 @@ function solve_cantellate_square_df(poly, df_min, df_max, steps=40, family_edge_
 //   profile = optional face profile rows supporting `["df", value]` and `["c", value]` overrides.
 //   cleanup = whether to run structural cleanup on the result.
 //   cleanup_eps = cleanup tolerance used when `cleanup=true`.
+//   style = `"strict"` or `"planarized"` topology.
+//   cap_mode = vertex-cap realization mode for `style="planarized"`.
 function poly_cantellate_norm(
     poly,
     c,
@@ -1011,12 +1118,14 @@ function poly_cantellate_norm(
     len_eps=1e-6,
     profile=undef,
     cleanup=false,
-    cleanup_eps=1e-8
+    cleanup_eps=1e-8,
+    style="strict",
+    cap_mode=undef
 ) =
     let(df = _ps_cantellate_df_from_c(poly, c, df_max, steps, family_edge_idx))
     poly_cantellate(
         poly, df, undef, df_max, steps, family_edge_idx, eps, len_eps, profile,
-        cleanup, cleanup_eps
+        cleanup, cleanup_eps, style, cap_mode
     );
 
 // --- Snub helpers ---

--- a/src/polysymmetrica/core/truncation.scad
+++ b/src/polysymmetrica/core/truncation.scad
@@ -809,6 +809,9 @@ function _ps_cantellate_vertex_raw_pts(face_pts, faces0, fan_faces, vi) =
                 face_pts[fi][pos]
     ];
 
+function _ps_cantellate_raw_pts_at_vertex(vertex_pt, raw_pts, eps) =
+    max([for (p = raw_pts) norm(p - vertex_pt)]) <= eps;
+
 function _ps_cantellate_cap_pts_by_vertex(verts0, faces0, face_pts, edges, edge_faces, poly0, cap_mode_by_vert, poly_center, eps) =
     [
         for (vi = [0:1:len(verts0)-1])
@@ -816,7 +819,9 @@ function _ps_cantellate_cap_pts_by_vertex(verts0, faces0, face_pts, edges, edge_
                 fan_faces = ps_vertex_fan_faces_idx(ps_vertex_fan(poly0, vi, edges, edge_faces)),
                 raw_pts = _ps_cantellate_vertex_raw_pts(face_pts, faces0, fan_faces, vi)
             )
-            ps_vertex_figure_points_from_raw(verts0[vi], raw_pts, cap_mode_by_vert[vi], poly_center, eps)
+            _ps_cantellate_raw_pts_at_vertex(verts0[vi], raw_pts, eps)
+                ? raw_pts
+                : ps_vertex_figure_points_from_raw(verts0[vi], raw_pts, cap_mode_by_vert[vi], poly_center, eps)
     ];
 
 function _ps_cantellate_cap_pts_by_face(verts0, faces0, edges, edge_faces, poly0, cap_pts_by_vertex) =

--- a/src/polysymmetrica/core/truncation.scad
+++ b/src/polysymmetrica/core/truncation.scad
@@ -822,6 +822,23 @@ function _ps_cantellate_vertex_ray_pts(verts0, faces0, face_pts, face_n, fan_fac
 function _ps_cantellate_raw_pts_at_vertex(vertex_pt, raw_pts, eps) =
     max([for (p = raw_pts) norm(p - vertex_pt)]) <= eps;
 
+function _ps_cantellate_distinct_points_count(pts, eps, acc=[], i=0) =
+    (i >= len(pts)) ? len(acc) :
+    let(p = pts[i])
+    (_ps_find_point(acc, p, eps) >= 0)
+        ? _ps_cantellate_distinct_points_count(pts, eps, acc, i + 1)
+        : _ps_cantellate_distinct_points_count(pts, eps, concat(acc, [p]), i + 1);
+
+function _ps_cantellate_cap_active_by_vertex(verts0, faces0, face_pts, edges, edge_faces, poly0, eps) =
+    [
+        for (vi = [0:1:len(verts0)-1])
+            let(
+                fan_faces = ps_vertex_fan_faces_idx(ps_vertex_fan(poly0, vi, edges, edge_faces)),
+                raw_pts = _ps_cantellate_vertex_raw_pts(face_pts, faces0, fan_faces, vi)
+            )
+            _ps_cantellate_distinct_points_count(raw_pts, eps) >= 3
+    ];
+
 function _ps_cantellate_vertex_plane_pts(vertex_pt, raw_pts, ray_pts, eps) =
     let(
         nonzero_offsets = [for (p = raw_pts) let(d = norm(p - vertex_pt)) if (d > eps) d],
@@ -868,13 +885,14 @@ function _ps_cantellate_cap_pts_by_face(verts0, faces0, edges, edge_faces, poly0
             ]
     ];
 
-function _ps_cantellate_vertex_connector_cycles(verts0, faces0, edges, edge_faces, poly0, face_offsets, cap_site_offset) =
+function _ps_cantellate_vertex_connector_cycles(verts0, faces0, edges, edge_faces, poly0, face_offsets, cap_site_offset, cap_active_by_vertex) =
     [
         for (vi = [0:1:len(verts0)-1])
             let(
                 fan_faces = ps_vertex_fan_faces_idx(ps_vertex_fan(poly0, vi, edges, edge_faces)),
                 n = len(fan_faces)
             )
+            if (cap_active_by_vertex[vi])
             for (i = [0:1:n-1])
                 let(
                     fi0 = fan_faces[i],
@@ -1000,6 +1018,9 @@ function poly_cantellate(
         face_offsets = _ps_face_offsets(faces0),
         face_pts_flat = [for (fi = [0:1:len(faces0)-1]) for (p = face_pts[fi]) p],
         cap_site_offset = len(face_pts_flat),
+        cap_active_by_vertex = (style == "planarized")
+            ? _ps_cantellate_cap_active_by_vertex(verts0, faces0, face_pts, edges, edge_faces, poly0, eps)
+            : undef,
         cap_pts_by_vertex = (style == "planarized")
             ? _ps_cantellate_cap_pts_by_vertex(verts0, faces0, face_pts, face_n, edges, edge_faces, poly0, cap_mode_by_vert, v_sum(verts0) / len(verts0), eps)
             : undef,
@@ -1047,16 +1068,17 @@ function poly_cantellate(
         vert_cycles = [
             for (vi = [0:1:len(verts0)-1])
                 let(fc = ps_vertex_fan_faces_idx(ps_vertex_fan(poly0, vi, edges, edge_faces)))
-                [
-                    for (fi = fc)
-                        let(pos = _ps_index_of(faces0[fi], vi))
-                            [1, (style == "planarized")
-                                ? _ps_cantellate_cap_site_idx(face_offsets, cap_site_offset, fi, pos)
-                                : _ps_cantellate_face_site_idx(face_offsets, fi, pos)]
-                ]
+                (style == "planarized" && !cap_active_by_vertex[vi]) ? [] :
+                    [
+                        for (fi = fc)
+                            let(pos = _ps_index_of(faces0[fi], vi))
+                                [1, (style == "planarized")
+                                    ? _ps_cantellate_cap_site_idx(face_offsets, cap_site_offset, fi, pos)
+                                    : _ps_cantellate_face_site_idx(face_offsets, fi, pos)]
+                    ]
         ],
         connector_cycles = (style == "planarized")
-            ? _ps_cantellate_vertex_connector_cycles(verts0, faces0, edges, edge_faces, poly0, face_offsets, cap_site_offset)
+            ? _ps_cantellate_vertex_connector_cycles(verts0, faces0, edges, edge_faces, poly0, face_offsets, cap_site_offset, cap_active_by_vertex)
             : [],
         cycles_all = concat(face_cycles, edge_cycles, connector_cycles, vert_cycles)
     )

--- a/src/polysymmetrica/core/truncation.scad
+++ b/src/polysymmetrica/core/truncation.scad
@@ -809,19 +809,50 @@ function _ps_cantellate_vertex_raw_pts(face_pts, faces0, fan_faces, vi) =
                 face_pts[fi][pos]
     ];
 
+function _ps_cantellate_vertex_ray_pts(verts0, faces0, face_pts, face_n, fan_faces, vi, eps) =
+    [
+        for (fi = fan_faces)
+            let(
+                pos = _ps_index_of(faces0[fi], vi),
+                raw_pt = face_pts[fi][pos]
+            )
+            (norm(raw_pt - verts0[vi]) <= eps) ? (verts0[vi] + face_n[fi]) : raw_pt
+    ];
+
 function _ps_cantellate_raw_pts_at_vertex(vertex_pt, raw_pts, eps) =
     max([for (p = raw_pts) norm(p - vertex_pt)]) <= eps;
 
-function _ps_cantellate_cap_pts_by_vertex(verts0, faces0, face_pts, edges, edge_faces, poly0, cap_mode_by_vert, poly_center, eps) =
+function _ps_cantellate_vertex_plane_pts(vertex_pt, raw_pts, ray_pts, eps) =
+    let(
+        nonzero_offsets = [for (p = raw_pts) let(d = norm(p - vertex_pt)) if (d > eps) d],
+        offset_scale = (len(nonzero_offsets) == 0) ? 1 : (ps_sum(nonzero_offsets) / len(nonzero_offsets))
+    )
+    [
+        for (i = [0:1:len(raw_pts)-1])
+            let(
+                raw_pt = raw_pts[i],
+                ray_dir_raw = ray_pts[i] - vertex_pt,
+                ray_dir_len = norm(ray_dir_raw)
+            )
+            (norm(raw_pt - vertex_pt) <= eps && ray_dir_len > eps)
+                ? (vertex_pt + offset_scale * ray_dir_raw / ray_dir_len)
+                : raw_pt
+    ];
+
+function _ps_cantellate_cap_pts_by_vertex(verts0, faces0, face_pts, face_n, edges, edge_faces, poly0, cap_mode_by_vert, poly_center, eps) =
     [
         for (vi = [0:1:len(verts0)-1])
             let(
                 fan_faces = ps_vertex_fan_faces_idx(ps_vertex_fan(poly0, vi, edges, edge_faces)),
-                raw_pts = _ps_cantellate_vertex_raw_pts(face_pts, faces0, fan_faces, vi)
+                raw_pts = _ps_cantellate_vertex_raw_pts(face_pts, faces0, fan_faces, vi),
+                ray_pts = _ps_cantellate_vertex_ray_pts(verts0, faces0, face_pts, face_n, fan_faces, vi, eps),
+                plane_pts = _ps_cantellate_vertex_plane_pts(verts0[vi], raw_pts, ray_pts, eps)
             )
             _ps_cantellate_raw_pts_at_vertex(verts0[vi], raw_pts, eps)
                 ? raw_pts
-                : ps_vertex_figure_points_from_raw(verts0[vi], raw_pts, cap_mode_by_vert[vi], poly_center, eps)
+                : (cap_mode_by_vert[vi] == "edge_fraction")
+                    ? raw_pts
+                    : _ps_vertex_figure_points_from_raw_on_rays(verts0[vi], plane_pts, ray_pts, cap_mode_by_vert[vi], poly_center, eps)
     ];
 
 function _ps_cantellate_cap_pts_by_face(verts0, faces0, edges, edge_faces, poly0, cap_pts_by_vertex) =
@@ -970,7 +1001,7 @@ function poly_cantellate(
         face_pts_flat = [for (fi = [0:1:len(faces0)-1]) for (p = face_pts[fi]) p],
         cap_site_offset = len(face_pts_flat),
         cap_pts_by_vertex = (style == "planarized")
-            ? _ps_cantellate_cap_pts_by_vertex(verts0, faces0, face_pts, edges, edge_faces, poly0, cap_mode_by_vert, v_sum(verts0) / len(verts0), eps)
+            ? _ps_cantellate_cap_pts_by_vertex(verts0, faces0, face_pts, face_n, edges, edge_faces, poly0, cap_mode_by_vert, v_sum(verts0) / len(verts0), eps)
             : undef,
         cap_pts = (style == "planarized")
             ? _ps_cantellate_cap_pts_by_face(verts0, faces0, edges, edge_faces, poly0, cap_pts_by_vertex)

--- a/src/tests/core/TestCantellation.scad
+++ b/src/tests/core/TestCantellation.scad
@@ -128,6 +128,21 @@ module test_poly_cantellate__profile_vertex_cap_mode() {
     assert(err > 1e-4, "vertex profile cap_mode=edge_fraction should preserve the raw skew cap at that vertex");
 }
 
+module test_poly_cantellate__planarized_preserves_zero_offset_endpoint() {
+    p = _irregular_valence4_bipyramid();
+    q_strict = poly_cantellate(p, df = 0, cleanup = true);
+    q_df0 = poly_cantellate(p, df = 0, style = "planarized", cleanup = true);
+    q_c0 = poly_cantellate_norm(p, c = 0, style = "planarized", cleanup = true);
+
+    assert_int_eq(len(poly_verts(q_df0)), len(poly_verts(q_strict)), "planarized df=0 should preserve strict vertex count");
+    assert_int_eq(len(poly_faces(q_df0)), len(poly_faces(q_strict)), "planarized df=0 should preserve strict face count");
+    assert(_max_vertex_diff(q_strict, q_df0) < 1e-7, "planarized df=0 should preserve strict endpoint vertices");
+
+    assert_int_eq(len(poly_verts(q_c0)), len(poly_verts(q_strict)), "planarized c=0 should preserve strict vertex count");
+    assert_int_eq(len(poly_faces(q_c0)), len(poly_faces(q_strict)), "planarized c=0 should preserve strict face count");
+    assert(_max_vertex_diff(q_strict, q_c0) < 1e-7, "planarized c=0 should preserve strict endpoint vertices");
+}
+
 module run_TestCantellation() {
     test_poly_cantellate__tetra_counts();
     test_poly_cantellate__cube_counts();
@@ -136,6 +151,7 @@ module run_TestCantellation() {
     test_poly_cantellate__planarized_keeps_tetrakis_faces_planar();
     test_poly_cantellate__planarized_edge_fraction_matches_strict();
     test_poly_cantellate__profile_vertex_cap_mode();
+    test_poly_cantellate__planarized_preserves_zero_offset_endpoint();
 }
 
 run_TestCantellation();

--- a/src/tests/core/TestCantellation.scad
+++ b/src/tests/core/TestCantellation.scad
@@ -6,6 +6,8 @@
 
 use <../../polysymmetrica/core/funcs.scad>
 use <../../polysymmetrica/core/truncation.scad>
+use <../../polysymmetrica/core/validate.scad>
+use <../../polysymmetrica/models/catalans_all.scad>
 use <../../polysymmetrica/models/platonics_all.scad>
 use <../testing_util.scad>
 
@@ -17,6 +19,43 @@ module assert_int_eq(a, b, msg="") {
 
 function _count_faces_of_size(poly, k) =
     ps_sum([ for (f = poly_faces(poly)) (len(f)==k) ? 1 : 0 ]);
+
+function _irregular_valence4_bipyramid() =
+    poly_make(
+        [
+            [0, 0, 1.7],
+            [1.4, 0, 0],
+            [0.2, 1.1, 0.35],
+            [-1.0, 0.1, -0.15],
+            [-0.1, -1.4, 0.25],
+            [0.1, 0, -1.2]
+        ],
+        [
+            [0, 2, 1],
+            [0, 3, 2],
+            [0, 4, 3],
+            [0, 1, 4],
+            [5, 1, 2],
+            [5, 2, 3],
+            [5, 3, 4],
+            [5, 4, 1]
+        ],
+        1
+    );
+
+function _max_vertex_diff(p1, p2) =
+    let(
+        v1 = poly_verts(p1),
+        v2 = poly_verts(p2),
+        n = min(len(v1), len(v2))
+    )
+    (n == 0) ? 0 : max([for (i = [0:1:n-1]) norm(v1[i] - v2[i])]);
+
+function _cantellate_source_vertex_faces(poly, q) =
+    let(
+        faces = poly_faces(q)
+    )
+    [for (i = [len(faces) - len(poly_verts(poly)):1:len(faces)-1]) faces[i]];
 
 module test_poly_cantellate__tetra_counts() {
     p = tetrahedron();
@@ -36,9 +75,67 @@ module test_poly_cantellate__cube_counts() {
     assert_int_eq(_count_faces_of_size(q, 4), 18, "cantellate cube: 18 quads");
 }
 
+module test_poly_cantellate__strict_exposes_irregular_vertex_cap_nonplanarity() {
+    p = _irregular_valence4_bipyramid();
+    q = poly_cantellate(p, df = 0.1);
+    verts = poly_verts(q);
+    vert_faces = _cantellate_source_vertex_faces(p, q);
+    err = _ps_faces_max_planarity_err(verts, vert_faces);
+
+    assert(err > 1e-4, str("strict cantellate should expose irregular source-vertex cap non-planarity err=", err));
+}
+
+module test_poly_cantellate__planarized_keeps_irregular_faces_planar() {
+    p = _irregular_valence4_bipyramid();
+    q = poly_cantellate(p, df = 0.1, style = "planarized");
+    err = _ps_faces_max_planarity_err(poly_verts(q), poly_faces(q));
+
+    assert(err <= 1e-7, str("planarized cantellate should keep all faces planar err=", err));
+    assert(poly_valid(q, "closed", 1e-7), "planarized cantellate irregular output should remain closed-valid");
+}
+
+module test_poly_cantellate__planarized_keeps_tetrakis_faces_planar() {
+    p = tetrakis_hexahedron();
+    q = poly_cantellate(p, df = 0.1, style = "planarized");
+    err = _ps_faces_max_planarity_err(poly_verts(q), poly_faces(q));
+
+    assert(err <= 1e-7, str("planarized cantellate tetrakis output should remain planar err=", err));
+    assert(poly_valid(q, "closed", 1e-7), "planarized cantellate tetrakis output should remain closed-valid");
+}
+
+module test_poly_cantellate__planarized_edge_fraction_matches_strict() {
+    p = _irregular_valence4_bipyramid();
+    q_strict = poly_cantellate(p, df = 0.1);
+    q_edge = poly_cantellate(p, df = 0.1, style = "planarized", cap_mode = "edge_fraction");
+
+    assert(_max_vertex_diff(q_strict, q_edge) < 1e-7, "planarized edge_fraction should collapse to strict cantellation points");
+    assert_int_eq(len(poly_verts(q_strict)), len(poly_verts(q_edge)), "planarized edge_fraction should collapse duplicate cap vertices");
+    assert_int_eq(len(poly_faces(q_strict)), len(poly_faces(q_edge)), "planarized edge_fraction should collapse degenerate connector faces");
+}
+
+module test_poly_cantellate__profile_vertex_cap_mode() {
+    p = _irregular_valence4_bipyramid();
+    q_profile = poly_cantellate(
+        p,
+        df = 0.1,
+        style = "planarized",
+        profile = [["vert", "id", 0, ["cap_mode", "edge_fraction"]]]
+    );
+    vert_faces = _cantellate_source_vertex_faces(p, q_profile);
+    apex_cap = vert_faces[0];
+    err = _ps_face_planarity_err(poly_verts(q_profile), apex_cap);
+
+    assert(err > 1e-4, "vertex profile cap_mode=edge_fraction should preserve the raw skew cap at that vertex");
+}
+
 module run_TestCantellation() {
     test_poly_cantellate__tetra_counts();
     test_poly_cantellate__cube_counts();
+    test_poly_cantellate__strict_exposes_irregular_vertex_cap_nonplanarity();
+    test_poly_cantellate__planarized_keeps_irregular_faces_planar();
+    test_poly_cantellate__planarized_keeps_tetrakis_faces_planar();
+    test_poly_cantellate__planarized_edge_fraction_matches_strict();
+    test_poly_cantellate__profile_vertex_cap_mode();
 }
 
 run_TestCantellation();

--- a/src/tests/core/TestCantellation.scad
+++ b/src/tests/core/TestCantellation.scad
@@ -149,7 +149,8 @@ module test_poly_cantellate__planarized_handles_partial_zero_face_profile() {
         p,
         df = 0,
         style = "planarized",
-        profile = [["face", "id", 0, ["df", 0.1]]]
+        profile = [["face", "id", 0, ["df", 0.1]]],
+        cleanup = true
     );
     q = poly_cantellate(
         p,
@@ -159,8 +160,7 @@ module test_poly_cantellate__planarized_handles_partial_zero_face_profile() {
         cleanup = true
     );
 
-    assert(len(poly_verts(q_sparse)) > 0, "planarized sparse face profile should construct without zero-ray assertion");
-    assert(len(poly_faces(q_sparse)) > 0, "planarized sparse face profile should return faces");
+    assert(poly_valid(q_sparse, "closed", 1e-7), "planarized sparse face profile should remain closed-valid");
     assert(poly_valid(q, "closed", 1e-7), "planarized selective face profile should support mixed zero/nonzero incidences");
 }
 

--- a/src/tests/core/TestCantellation.scad
+++ b/src/tests/core/TestCantellation.scad
@@ -143,6 +143,27 @@ module test_poly_cantellate__planarized_preserves_zero_offset_endpoint() {
     assert(_max_vertex_diff(q_strict, q_c0) < 1e-7, "planarized c=0 should preserve strict endpoint vertices");
 }
 
+module test_poly_cantellate__planarized_handles_partial_zero_face_profile() {
+    p = _irregular_valence4_bipyramid();
+    q_sparse = poly_cantellate(
+        p,
+        df = 0,
+        style = "planarized",
+        profile = [["face", "id", 0, ["df", 0.1]]]
+    );
+    q = poly_cantellate(
+        p,
+        df = 0.1,
+        style = "planarized",
+        profile = [["face", "id", 0, ["df", 0]]],
+        cleanup = true
+    );
+
+    assert(len(poly_verts(q_sparse)) > 0, "planarized sparse face profile should construct without zero-ray assertion");
+    assert(len(poly_faces(q_sparse)) > 0, "planarized sparse face profile should return faces");
+    assert(poly_valid(q, "closed", 1e-7), "planarized selective face profile should support mixed zero/nonzero incidences");
+}
+
 module run_TestCantellation() {
     test_poly_cantellate__tetra_counts();
     test_poly_cantellate__cube_counts();
@@ -152,6 +173,7 @@ module run_TestCantellation() {
     test_poly_cantellate__planarized_edge_fraction_matches_strict();
     test_poly_cantellate__profile_vertex_cap_mode();
     test_poly_cantellate__planarized_preserves_zero_offset_endpoint();
+    test_poly_cantellate__planarized_handles_partial_zero_face_profile();
 }
 
 run_TestCantellation();


### PR DESCRIPTION
  - src/polysymmetrica/core/truncation.scad: added poly_cantellate(..., style="strict"|"planarized", cap_mode=...).
  - Strict mode preserves existing shared-site topology.
  - Planarized mode realizes separate vertex cap sites with the shared vertex-figure helper, then bridges raw face/edge sites to planar cap sites with connector quads.
  - poly_cantellate_norm passes the same controls through.
  - src/tests/core/TestCantellation.scad: added irregular/tetrakis planarity tests, strict non-planarity coverage, edge-fraction equivalence, and profile cap_mode coverage.
  - docs/guides/cantellation.md and docs/guides/profile.md: documented the new style/cap-mode/profile behavior.
